### PR TITLE
LIBDRUM-653. Disabled the default password authenticator.

### DIFF
--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -54,7 +54,7 @@
 
 # Authentication by Password (encrypted in DSpace's database). See authentication-password.cfg for default configuration.
 # Enabled by default (to disable, either comment out, or define a new list of AuthenticationMethod plugins in your local.cfg)
-plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
+#plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
 
 
 #---------------------------------------------------------------#


### PR DESCRIPTION
The list in the dspace.cfg was appending to the list in the authentication.cfg instead of replacing it, causing the PasswordAuthenticator to be listed twice in the list of authentication methods.

https://issues.umd.edu/browse/LIBDRUM-653