### PR TITLE
LIBDRUM-687. Replaced "wget" with "curl" when building "Dockerfile.ant"

### DIFF
--- a/Dockerfile.ant
+++ b/Dockerfile.ant
@@ -5,4 +5,4 @@ ENV ANT_VERSION 1.10.7
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
-    wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
+    curl --silent "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME


### PR DESCRIPTION
Replaced "wget" command with the equivalent "curl" command, as "wget"
no longer appears to be provided by default by the upstream base Docker
image.

https://issues.umd.edu/browse/LIBDRUM-687
