### PR TITLE
LIBDRUM-695. Ensure CNRI Handle server has necessary dependencies

### DIFF
--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -367,6 +367,65 @@
          <scope>test</scope>
       </dependency>
 
+      <!-- UMD Customization: LIBDRUM-695
+          The following dependencies are required by the CNRI Handle Server,
+          but are excluded in the "cnri-servlet-container" dependency in
+          the "dspace-api/pom/xml" file.
+
+          As of DSpace 7.3, no other dependencies used by DSpace require
+          these dependencies as "compile" dependencies. They are being added
+          here so that they will be available to the CNRI Handle Server when
+          run in the "handle-server" container as part of the "drum-0"
+          Kubernetes pod.
+
+          The continued need for these dependencies should be re-evaluated
+          when new DSpace releases are made.
+
+          Note: These dependencies are using the Jetty version defined by
+          DSpace, not the version specified by the "cnri-servlet-container"
+          dependency.
+      -->
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-alpn-java-server</artifactId>
+         <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty</groupId>
+           <artifactId>jetty-deploy</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty</groupId>
+           <artifactId>jetty-servlet</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty</groupId>
+           <artifactId>jetty-servlets</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty</groupId>
+           <artifactId>jetty-webapp</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty</groupId>
+           <artifactId>jetty-xml</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty.http2</groupId>
+           <artifactId>http2-common</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+           <groupId>org.eclipse.jetty.http2</groupId>
+           <artifactId>http2-server</artifactId>
+           <version>${jetty.version}</version>
+      </dependency>
+      <!-- END UMD Customization: LIBDRUM-695 -->
    </dependencies>
 
 </project>


### PR DESCRIPTION
In the "dspace-api/pom.xml" file, the Jetty dependencies for the
"cnri-servlet-container" (the CNRI Handle Server) are excluded because
they conflict with Jetty versions provided by DSpace.

In DSpace 7.3, the Jetty dependencies used by the
"cnri-servlet-container" are still excluded, but no other DSpace
dependency includes the Jetty dependencies as "compile" dependencies
(they are included as "test" dependencies, which does not get them
included in the the final assembly package).

To ensure that the CNRI Handle Server has the necessary dependencies,
adding them as explicit dependencies (using the DSpace Jetty version)
to the "dspace/modules/additions/pom.xml" file.

The need for these dependencies should be re-evaluated when new DSpace
releases are made.

https://issues.umd.edu/browse/LIBDRUM-695
