### PR TITLE
LIBDRUM-675. Customize default submission fields

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -19,8 +19,11 @@
     <submission-map>
         <!-- Default submission process -->
         <name-map collection-handle="default" submission-name="traditional"/>
+        <!-- Customization for LIBDRUM-696 - Commenting out LIBDRUM-347 and
+             LIBDRUM-581 customiations until DSpace 7 implementations are
+             available.
         <name-map collection-handle="1903/11324" submission-name="LibraryAward" />
-        <name-map collection-handle="1903/21769" submission-name="MHHEA_Collection" />
+        <name-map collection-handle="1903/21769" submission-name="MHHEA_Collection" /> -->
 
         <!-- Sample Entities Collection configuration based on the demo Entities dataset available at:
              https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
@@ -207,15 +210,17 @@
         </step-definition>
 
         <!-- Customization for LIBDRUM-347 -->
-        <step-definition id="libraryAwardUploadForm">
+        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
+            <step-definition id="libraryAwardUploadForm">
             <heading>Library Award</heading>
             <processing-class>edu.umd.lib.dspace.submit.step.LibraryAwardUploadStep</processing-class>
             <type>submission-form</type>
-        </step-definition>
+        </step-definition> -->
         <!-- End Customization for LIBDRUM-347 -->
 
         <!-- Customization for LIBDRUM-581 -->
-        <step-definition id="optionalUpload">
+        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
+            <step-definition id="optionalUpload">
             <heading>submit.progressbar.upload</heading>
             <processing-class>org.dspace.submit.step.OptionalUploadStep</processing-class>
             <type>upload</type>
@@ -225,7 +230,7 @@
             <processing-class>org.dspace.submit.step.ConditionalLicenseStep</processing-class>
             <type>license</type>
             <scope visibilityOutside="read-only">submission</scope>
-        </step-definition>
+        </step-definition> -->
         <!-- End Customization for LIBDRUM-581 -->
 
         <step-definition id="sherpaPolicies" mandatory="true">
@@ -282,24 +287,26 @@
 
         <!-- Customization for LIBDRUM-347 -->
         <!--This "LibraryAward" process defines the DEFAULT item submission process -->
-        <submission-process name="LibraryAward">
+        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
+            <submission-process name="LibraryAward">
             <step id="collection"/>
             <step id="traditionalpageone"/>
             <step id="traditionalpagetwo"/>
             <step id="libraryAwardUploadForm"/>
             <step id="license"/>
-        </submission-process>
+        </submission-process> -->
         <!-- End Customization for LIBDRUM-347 -->
 
         <!-- Customization for LIBDRUM-581 -->
         <!--This "MHHEA_Collection" process defines the DEFAULT item submission process -->
+        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
         <submission-process name="MHHEA_Collection">
             <step id="collection"/>
             <step id="traditionalpageone"/>
             <step id="traditionalpagetwo"/>
             <step id="optionalUpload"/>
             <step id="conditionalLicense"/>
-        </submission-process>
+        </submission-process> -->
         <!-- End Customization for LIBDRUM-581 -->
 
         <!--

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -65,6 +65,20 @@
                     <!-- End customization for LIBDRUM-675 -->
                 </field>
             </row>
+            <!-- UMD customization for LIBDRUM-675 -->
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>advisor</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Advisor</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the advisor's name (Family name, Given names).</hint>
+                    <required></required>
+                </field>
+            </row>
+            <!-- End customization for LIBDRUM-675 -->
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -60,7 +60,9 @@
                     <label>Author</label>
                     <input-type>onebox</input-type>
                     <hint>Enter the author's name (Family name, Given names).</hint>
-                    <required></required>
+                    <!-- UMD customization for LIBDRUM-675 -->
+                    <required>You must enter an author for this item.</required>
+                    <!-- End customization for LIBDRUM-675 -->
                 </field>
             </row>
             <row>


### PR DESCRIPTION
Customized the submission form for default submissions:

* Made "Author" field required
* Added "Advisor" field

Note: The "file upload required" and "date.issued required" specification
for this issue are DSpace 7 defaults ("date.issued" requires at least a "year"
to be entered), and so required no modifications.

This pull request also has changes from LIBDRUM-696, where all UMD
customizations were commented out of the "dspace/config/item-submission.xml"
file, as the related Java classes have not yet been updated for DSpace 7.

https://issues.umd.edu/browse/LIBDRUM-675