### PR TITLE
LIBDRUM-684. MHHEA collection custom workflow

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -20,10 +20,15 @@
         <!-- Default submission process -->
         <name-map collection-handle="default" submission-name="traditional"/>
         <!-- Customization for LIBDRUM-696 - Commenting out LIBDRUM-347 and
-             LIBDRUM-581 customiations until DSpace 7 implementations are
+             LIBDRUM-581 customizations until DSpace 7 implementations are
              available.
         <name-map collection-handle="1903/11324" submission-name="LibraryAward" />
-        <name-map collection-handle="1903/21769" submission-name="MHHEA_Collection" /> -->
+        -->
+
+        <!-- Customization for LIBDRUM-684 - Enable separate submisson process
+             for  "Minority Health and Health Equity Archive" collection -->
+        <name-map collection-handle="1903/21769" submission-name="MHHEA_Collection" />
+        <!-- End Customization for LIBDRUM-684 -->
 
         <!-- Sample Entities Collection configuration based on the demo Entities dataset available at:
              https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
@@ -297,17 +302,18 @@
         </submission-process> -->
         <!-- End Customization for LIBDRUM-347 -->
 
-        <!-- Customization for LIBDRUM-581 -->
-        <!--This "MHHEA_Collection" process defines the DEFAULT item submission process -->
-        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
+        <!-- Customization for LIBDRUM-684 -->
+        <!--This "MHHEA_Collection" process replaces the DEFAULT item submission
+            process for the "Minority Health and Health Equity Archive"
+            collection -->
         <submission-process name="MHHEA_Collection">
             <step id="collection"/>
             <step id="traditionalpageone"/>
             <step id="traditionalpagetwo"/>
-            <step id="optionalUpload"/>
-            <step id="conditionalLicense"/>
+            <step id="upload"/>
+            <step id="license"/>
         </submission-process> -->
-        <!-- End Customization for LIBDRUM-581 -->
+        <!-- End Customization for LIBDRUM-684 -->
 
         <!--
         Submission Process for 'Publication' Entities.

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -223,13 +223,16 @@
         </step-definition> -->
         <!-- End Customization for LIBDRUM-347 -->
 
-        <!-- Customization for LIBDRUM-581 -->
-        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
-            <step-definition id="optionalUpload">
+        <!-- Customization for LIBDRUM-684 -->
+        <step-definition id="optionalUpload">
             <heading>submit.progressbar.upload</heading>
-            <processing-class>org.dspace.submit.step.OptionalUploadStep</processing-class>
+            <processing-class>org.dspace.app.rest.submit.step.UploadStep</processing-class>
             <type>upload</type>
         </step-definition>
+        <!-- End Customization for LIBDRUM-684 -->
+
+        <!-- Customization for LIBDRUM-581 -->
+        <!-- Commented out for LIBDRUM-696, until DSpace 7 implementation is available.
         <step-definition id="conditionalLicense">
             <heading>submit.progressbar.license</heading>
             <processing-class>org.dspace.submit.step.ConditionalLicenseStep</processing-class>
@@ -310,7 +313,7 @@
             <step id="collection"/>
             <step id="traditionalpageone"/>
             <step id="traditionalpagetwo"/>
-            <step id="upload"/>
+            <step id="optionalUpload"/>
             <step id="license"/>
         </submission-process> -->
         <!-- End Customization for LIBDRUM-684 -->

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -246,6 +246,14 @@
             <processing-class>org.dspace.app.rest.submit.step.SherpaPolicyStep</processing-class>
             <type>sherpaPolicy</type>
         </step-definition>
+
+        <!-- Customization for LIBDRUM-684 -->
+        <step-definition id="MHHEApageone" mandatory="true">
+            <heading>submit.progressbar.describe.stepone</heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+        <!-- End customization for LIBDRUM-684 -->
     </step-definitions>
 
     <!-- The submission-definitions map lays out the detailed definition of -->
@@ -311,7 +319,7 @@
             collection -->
         <submission-process name="MHHEA_Collection">
             <step id="collection"/>
-            <step id="traditionalpageone"/>
+            <step id="MHHEApageone"/>
             <step id="traditionalpagetwo"/>
             <step id="optionalUpload"/>
             <step id="license"/>

--- a/dspace/config/spring/api/access-conditions.xml
+++ b/dspace/config/spring/api/access-conditions.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
-	
+
 	<bean id="uploadConfigurationDefault" class="org.dspace.submit.model.UploadConfiguration">
 		<property name="name" value="upload"></property>
 		<property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
@@ -18,7 +18,25 @@
             </list>
         </property>
     </bean>
-  
+
+  <!-- Customization for LIBDRUM-684 -->
+  <bean id="uploadConfigurationOptional" class="org.dspace.submit.model.UploadConfiguration">
+    <property name="name" value="upload"></property>
+    <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    <property name="metadata" value="bitstream-metadata" />
+    <property name="options">
+      <list>
+          <ref bean="openAccess"/>
+          <ref bean="lease"/>
+          <ref bean="embargoed" />
+          <ref bean="administrator"/>
+           <!-- <ref bean="networkAdministration"/> -->
+      </list>
+    </property>
+    <property name="required" value="false"/>
+  </bean>
+  <!-- Customization for LIBDRUM-684 -->
+
     <bean id="openAccess" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>
         <property name="name" value="openaccess"/>
@@ -31,32 +49,35 @@
         <property name="hasStartDate" value="false"/>
         <property name="hasEndDate" value="true"/>
         <property name="endDateLimit" value="+6MONTHS"/>
-    </bean> 
+    </bean>
     <bean id="embargoed" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>
         <property name="name" value="embargo"/>
         <property name="hasStartDate" value="true"/>
         <property name="startDateLimit" value="+36MONTHS"/>
         <property name="hasEndDate" value="false"/>
-        
-    </bean> 
+
+    </bean>
     <bean id="administrator" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Administrator"/>
         <property name="name" value="administrator"/>
         <property name="hasStartDate" value="false"/>
-        <property name="hasEndDate" value="false"/>       
+        <property name="hasEndDate" value="false"/>
     </bean>
 <!--     <bean id="networkAdministration" class="org.dspace.submit.model.AccessConditionOption">
     	<property name="groupName" value="INSTITUTIONAL_NETWORK"/>
         <property name="name" value="networkAdministration"/>
         <property name="hasStartDate" value="false"/>
-        <property name="hasEndDate" value="false"/>                
+        <property name="hasEndDate" value="false"/>
     </bean> -->
 
     <bean id="uploadConfigurationService" class="org.dspace.submit.model.UploadConfigurationService">
         <property name="map">
             <map>
                 <entry key="upload" value-ref="uploadConfigurationDefault" />
+                <!-- Customization for LIBDRUM-684 -->
+                <entry key="optionalUpload" value-ref="uploadConfigurationOptional" />
+                <!-- Customization for LIBDRUM-684 -->
             </map>
         </property>
     </bean>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1364,6 +1364,179 @@
             </row>
         </form>
 
+        <!-- Customization for LIBDRUM-684 -->
+        <!-- Form which defines the first page/section of the "MHHEA" DSpace submission process,
+             based on the "traditionalpageone", with modifications. -->
+        <form name="MHHEApageone">
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>author</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Author</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the author's name (Family name, Given names).</hint>
+                    <!-- UMD customization for LIBDRUM-675 -->
+                    <required>You must enter an author for this item.</required>
+                    <!-- End customization for LIBDRUM-675 -->
+                </field>
+            </row>
+            <!-- UMD customization for LIBDRUM-675 -->
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>advisor</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Advisor</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the advisor's name (Family name, Given names).</hint>
+                    <required></required>
+                </field>
+            </row>
+            <!-- End customization for LIBDRUM-675 -->
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Title</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the main title of the item.</hint>
+                    <required>You must enter a main title for this item.</required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier>alternative</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Other Titles</label>
+                    <input-type>onebox</input-type>
+                    <hint>If the item has any alternative titles, please enter them here.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>date</dc-element>
+                    <dc-qualifier>issued</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Date of Issue</label>
+                    <style>col-sm-4</style>
+                    <input-type>date</input-type>
+                    <hint>Please give the date of previous publication or public distribution.
+                        You can leave out the day and/or month if they aren't applicable.
+                    </hint>
+                    <required>You must enter at least the year.</required>
+                </field>
+            </row>
+            <!-- Customization for LIBDRUM-684 -->
+            <row>
+                <field>
+                  <dc-schema>dc</dc-schema>
+                  <dc-element>description</dc-element>
+                  <dc-qualifier>uri</dc-qualifier>
+                  <repeatable>true</repeatable>
+                  <label>External Link</label>
+                  <input-type>onebox</input-type>
+                  <hint>
+                    If applicable, enter the URL(s) for the item located elsewhere on the Internet.
+                    If available, please use the DOI (Digital Object Identifier) for the file.
+                    Examples: https://drum.lib.umd.edu/, https://doi.org/10.13016/yhab-ufvn, or
+                    DOI:10.13016/yhab-ufvn.
+                  </hint>
+                  <required></required>
+                </field>
+            </row>
+            <!-- End customization for LIBDRUM-684 -->
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>publisher</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Publisher</label>
+                    <style>col-sm-8</style>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier>citation</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Citation</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>relation</dc-element>
+                    <dc-qualifier>ispartofseries</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Series/Report No.</label>
+                    <input-type>series</input-type>
+                    <hint>Enter the series and number assigned to this item by your community.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <label>Identifiers</label>
+                    <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+                    <hint>If the item has any identification numbers or codes associated with
+                        it, please enter the types and the actual numbers or codes.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>type</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Type</label>
+                    <input-type value-pairs-name="common_types">dropdown</input-type>
+                    <hint>Select the type of content of the item.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>language</dc-element>
+                    <dc-qualifier>iso</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Language</label>
+                    <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+                    <hint>Select the language of the main content of the item. If the language does not appear in the
+                        list, please select 'Other'. If the content does not really have a language (for example, if it
+                        is a dataset or an image) please select 'N/A'.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+        </form>
+        <!-- End Customization for LIBDRUM-684 -->
+
     </form-definitions>
 
 

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1451,6 +1451,7 @@
                     DOI:10.13016/yhab-ufvn.
                   </hint>
                   <required></required>
+                  <regex>^(https*|DOI):(\/\/)*.*</regex>
                 </field>
             </row>
             <!-- End customization for LIBDRUM-684 -->


### PR DESCRIPTION
Added custom workflow for the "Minority Heath and Health
Equity Archive" collection, based on the workflow in DSpace 6.

The major changes are:

* File uploads are optional
* An "External Link" field has been added.

Current implementation only utilitizes DSpace 7 configuration
options, and does not attempt to create new input fields or
otherwise change the behavior of the Angular front-end.
This implementation has the following limitations (compared to
DSpace 6):

* The "upload" and "license" fields are always shown, and the
"license" must be accepted even if no file is uploaded.
* The "External Link" validation is performed using a regex
expression, which is currently not as flexible as the DSpace 6
equivalent (which appears to use the browser's "url" input type
validation). Currently the regex expects the "http"/"https" identifier
to always be lower-case.
* The "File Description" field on an uploaded file can be entered, but
is somewhat hidden by the GUI.

https://issues.umd.edu/browse/LIBDRUM-684