### PR TITLE
LIBDRUM-669. Modified LDAP to return matched/unmatch Units

### DIFF
--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/authenticate/impl/Ldap.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/authenticate/impl/Ldap.java
@@ -147,9 +147,46 @@ public class Ldap {
      * @throws NamingException if an error is encountered while retrieving the
      * value.
      */
-    public List<String> getUnits() throws NamingException {
+    protected List<String> getLdapOrganizationalUnits() throws NamingException {
         return getAttributeAll("ou");
     }
+
+    /**
+     * Returns a List of Units in DSpace that match the LDAP organizational
+     * units of the user
+     */
+    public List<Unit> getMatchedUnits(Context context) throws NamingException, java.sql.SQLException {
+        List<Unit> units = new ArrayList<>();
+        for (Iterator<String> i = getLdapOrganizationalUnits().iterator(); i.hasNext();) {
+            String strUnit = (String) i.next();
+
+            Unit unit = unitService.findByName(context, strUnit);
+
+            if (unit != null) {
+                units.add(unit);
+            }
+        }
+        return units;
+    }
+
+    /**
+     * Returns a List of String representing the LDAP organizational units for
+     * the user that do not have a corresponding DSpace Unit.
+     */
+    public List<String> getUnmatchedUnits(Context context) throws NamingException, java.sql.SQLException {
+        List<String> additionalUnits = new ArrayList<>();
+        for (Iterator<String> i = getLdapOrganizationalUnits().iterator(); i.hasNext();) {
+            String strUnit = (String) i.next();
+
+            Unit unit = unitService.findByName(context, strUnit);
+
+            if (unit == null) {
+                additionalUnits.add(strUnit);
+            }
+        }
+        return additionalUnits;
+    }
+
 
     /**
      * Returns true if the user is College Park faculty with an acceptable
@@ -216,7 +253,7 @@ public class Ldap {
     public List<Group> getGroups(Context context) throws NamingException, java.sql.SQLException {
         HashSet<Group> ret = new HashSet<>();
 
-        for (Iterator<String> i = getUnits().iterator(); i.hasNext();) {
+        for (Iterator<String> i = getLdapOrganizationalUnits().iterator(); i.hasNext();) {
             String strUnit = i.next();
 
             Unit unit = unitService.findByName(context, strUnit);

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/model/LdapRest.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/model/LdapRest.java
@@ -21,6 +21,9 @@ public class LdapRest extends DSpaceObjectRest {
     private String name;
     private List<GroupRest> groups;
 
+    private List<UnitRest> matchedUnits;
+    private List<String> unmatchedUnits;
+
     @Override
     public String getCategory() {
         return CATEGORY;
@@ -106,5 +109,21 @@ public class LdapRest extends DSpaceObjectRest {
 
     public List<GroupRest> getGroups() {
         return groups;
+    }
+
+    public void setMatchedUnits(List<UnitRest> unitList) {
+        this.matchedUnits = unitList;
+    }
+
+    public List<UnitRest> getMatchedUnits() {
+        return matchedUnits;
+    }
+
+    public void setUnmatchedUnits(List<String> unmatchedUnitsList) {
+        this.unmatchedUnits = unmatchedUnitsList;
+    }
+
+    public List<String> getUnmatchedUnits() {
+        return this.unmatchedUnits;
     }
 }

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/repository/EPersonLdapLinkRepository.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/repository/EPersonLdapLinkRepository.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 import edu.umd.lib.dspace.authenticate.LdapService;
 import edu.umd.lib.dspace.authenticate.impl.LdapServiceImpl;
 import edu.umd.lib.dspace.authenticate.impl.Ldap;
+import org.dspace.app.rest.model.UnitRest;
 
 /**
  * Link repository for the direct Ldap subresource of an individual eperson.
@@ -84,6 +85,12 @@ public class EPersonLdapLinkRepository extends AbstractDSpaceRestRepository
                 List<GroupRest> groupList = ldap.getGroups(context).stream()
                     .map(g -> (GroupRest) converter.toRest(g, projection)).collect(Collectors.toList());
                 ldapRest.setGroups(groupList);
+
+                List<UnitRest> matchedUnitsList = ldap.getMatchedUnits(context).stream()
+                    .map(u -> (UnitRest) converter.toRest(u, projection)).collect(Collectors.toList());
+                ldapRest.setMatchedUnits(matchedUnitsList);
+
+                ldapRest.setUnmatchedUnits(ldap.getUnmatchedUnits(context));
 
                 return ldapRest;
             } catch (NamingException ne) {


### PR DESCRIPTION
Modified "Ldap" class and associated classes to return all the Units an EPerson matches based on their LDAP criteria, separating them into "matched" (a Unit with that name exists in DSpace) and "unmatched" (a Unit with that name does not exist in DSpace).

https://issues.umd.edu/browse/LIBDRUM-669

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
