### PR TITLE
LIBDRUM-710. Fix ETD Loader email templates

### DIFF
--- a/dspace/config/emails/duplicate_title
+++ b/dspace/config/emails/duplicate_title
@@ -1,5 +1,5 @@
 ## Email sent by DRUM when a duplicate title is detected on ETD load
-#set($subject = 'Subject: DRUM: duplicate title detected')
+#set($subject = 'DRUM: duplicate title detected')
 The following record was loaded using a batch loader and one or more items
 already in the system have the same title.
 

--- a/dspace/config/emails/duplicate_title
+++ b/dspace/config/emails/duplicate_title
@@ -1,8 +1,9 @@
-Subject: DRUM: duplicate title detected
+## Email sent by DRUM when a duplicate title is detected on ETD load
+#set($subject = 'Subject: DRUM: duplicate title detected')
 The following record was loaded using a batch loader and one or more items
 already in the system have the same title.
 
-title:      {0}
-id:         {1}
-handle:     {2}
-collection: {3}
+title:      ${params[0]}
+id:         ${params[1]}
+handle:     ${params[2]}
+collection: ${params[3]}

--- a/dspace/config/emails/etd_collections
+++ b/dspace/config/emails/etd_collections
@@ -1,7 +1,8 @@
-Subject: DRUM: incoming etd is missing mapped collection(s)
+## Email sent by DRUM when a mapped collection is not found
+#set($subject = 'DRUM: incoming etd is missing mapped collection(s)')
 Unable to map DISS_inst_contact to additional collection(s).
 
-title:      {0}
-id:         {1}
-handle:     {2}
-collection: {3}
+title:      ${params[0]}
+id:         ${params[1]}
+handle:     ${params[2]}
+collection: ${params[3]}

--- a/dspace/docs/Drum7DockerDevelopmentEnvironment.md
+++ b/dspace/docs/Drum7DockerDevelopmentEnvironment.md
@@ -184,7 +184,7 @@ mvn install
 ## DSpace Scripts and Email Setup
 
 DSpace scripts (such as [../bin/load-etd](../bin/load-etd)) may send email as
-part of their operation. The development Docker images do not, by themselves
+part of their operation. The development Docker images do not, by themselves,
 support running the DSpace scripts or sending emails.
 
 The following changes enable the DSpace scripts to be run in the "dspace"

--- a/dspace/docs/Drum7DockerDevelopmentEnvironment.md
+++ b/dspace/docs/Drum7DockerDevelopmentEnvironment.md
@@ -181,6 +181,75 @@ root directory:
 mvn install
 ```
 
+## DSpace Scripts and Email Setup
+
+DSpace scripts (such as [../bin/load-etd](../bin/load-etd)) may send email as
+part of their operation. The development Docker images do not, by themselves
+support running the DSpace scripts or sending emails.
+
+The following changes enable the DSpace scripts to be run in the "dspace"
+Docker container, with email being captured by the "MailHog" application, which
+is accessible at <http://localhost:8025/>.
+
+**Note:** After making the following changes, the "Dockerfile.dev-base" and
+"Dockerfile.dev-additions" Docker images need to be rebuilt.
+
+### Dockerfile.dev-additions
+
+Add the following lines to the "Dockerfile.dev-additions" file, just after the
+`FROM tomcat:9-jdk${JDK_VERSION}` line, to include the packages needed for the
+script and email functionality:
+
+```text
+FROM tomcat:9-jdk${JDK_VERSION}
+
+# Dependencies for email functionality
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      csh \
+      postfix \
+      s-nail \
+      libgetopt-complete-perl \
+      libconfig-properties-perl \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkfifo /var/spool/postfix/public/pickup
+# End Dependencies for email functionality
+```
+
+### docker-compose.yml
+
+Add the following lines to the "docker-compose.yml" file, in the "service"
+stanza, to enable the "MailHog" <https://github.com/mailhog/MailHog> SMTP
+capture tool as part of the Docker Compose stack:
+
+```yaml
+service:
+  ...
+  # MailHog SMTP Capture
+  mailhog:
+    container_name: mailhog
+    image: mailhog/mailhog:v1.0.1
+    networks:
+      dspacenet:
+    logging:
+      driver: 'none'  # disable saving logs
+    ports:
+      - 1025:1025 # smtp server
+      - 8025:8025 # web ui
+  # End MailHog SMTP Capture
+```
+
+### dspace/config/local.cfg
+
+Set the following values in the "dspace/config/local.cfg" file, replacing the
+existing values:
+
+```text
+mail.server = mailhog
+mail.server.port = 1025
+```
+
 ---
 [testenv]: <../../src/main/assembly/testEnvironment.xml>
 [testenv-add]: <../../src/main/assembly/testEnvironment-additions.xml>

--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/app/EtdLoader.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/app/EtdLoader.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2006 The University of Maryland. All Rights Reserved.
- * 
+ *
  */
 
 package edu.umd.lib.dspace.app;
@@ -105,7 +105,7 @@ import org.xml.sax.InputSource;
 
 /*********************************************************************
  * ETD Loader. Algorithm:
- * 
+ *
  * <pre>
  *    get params
  *    get properties
@@ -123,7 +123,7 @@ import org.xml.sax.InputSource;
  *      if duplicate title send email notice
  *      if no mapped collections send email notice
  * </pre>
- * 
+ *
  * @author Ben Wallberg
  *********************************************************************/
 
@@ -296,7 +296,7 @@ public class EtdLoader {
         }
 
         catch (Exception e) {
-            log.error("Uncaught exception: " + e.getMessage());
+            log.error("Uncaught exception: " + e.getMessage(), e);
         }
 
         finally {
@@ -565,6 +565,12 @@ public class EtdLoader {
                             sbCollections.append(coll.getName());
                         }
 
+                        String handle = handleService.findHandle(c, item);
+                        String collection = sbCollections.toString();
+                        String itemId = "" + item.getID();
+                        log.warn("Duplicate title: title: '{}', id: '{}', handle: '{}', collection: '{}'",
+                            searchTitle, itemId, handle, collection);
+
                         // Get the email recipient
                         String email = configurationService
                                 .getProperty("drum.mail.duplicate_title");
@@ -579,9 +585,9 @@ public class EtdLoader {
                                         .getEmail(I18nUtil.getEmailFilename(Locale.getDefault(), "duplicate_title"));
                                 bean.addRecipient(email);
                                 bean.addArgument(searchTitle);
-                                bean.addArgument("" + item.getID());
-                                bean.addArgument(handleService.findHandle(c, item));
-                                bean.addArgument(sbCollections.toString());
+                                bean.addArgument(itemId);
+                                bean.addArgument(handle);
+                                bean.addArgument(collection);
                                 bean.send();
                             }
                         } catch (Exception e) {


### PR DESCRIPTION
DSpace 7 uses the Apache Velocity template engine,
so updates the following email template files to use
Apache Velocity syntax, instead of the Java MessageFormat
syntax:

* dspace/config/emails/duplicate_title
* dspace/config/emails/etd_collections

Also modified the "dspace/modules/additions/src/main/java/edu/umd/lib/dspace/app/EtdLoader.java" file
to provide a "Duplicate title" message in the script output, and provided information in the "dspace/docs/Drum7DockerDevelopmentEnvironment.md" file on setting up the development Docker images to
enable them to run the scripts and capture the email output.

https://issues.umd.edu/browse/LIBDRUM-710