### PR TITLE
LIBDRUM-682. Implement Data Community submission form/workflow

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -392,7 +392,7 @@ wufoo.feedback.field.session = Field11
 wufoo.feedback.field.host = Field15
 
 # Data Community
-data.community.handle =
+data.community.handle = 1903/27669
 
 # Equitable Access Policy
 # The handle for the "Equitable Access Policy" community

--- a/dspace/config/spring/api/workflow-actions.xml
+++ b/dspace/config/spring/api/workflow-actions.xml
@@ -104,5 +104,15 @@
         <property name="processingAction" ref="equitableAccessCollectionMappingAPI"/>
         <property name="requiresUI" value="false"/>
     </bean>
+
+    <bean id="dataCommunityCollectionMappingAPI"
+        class="edu.umd.lib.dspace.xmlworkflow.state.actions.DataCommunityCollectionMappingAction"
+        scope="prototype"/>
+
+    <bean id="datacommunitycollectionmappingaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="datacommunitycollectionmappingaction"/>
+        <property name="processingAction" ref="dataCommunityCollectionMappingAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
     <!-- End UMD customization -->
 </beans>

--- a/dspace/config/spring/api/workflow.xml
+++ b/dspace/config/spring/api/workflow.xml
@@ -213,6 +213,7 @@
         <property name="actions">
             <list>
                 <ref bean="equitableaccesscollectionmappingaction"/>
+                <ref bean="datacommunitycollectionmappingaction"/>
             </list>
         </property>
     </bean>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1461,13 +1461,47 @@
                     <dc-element>description</dc-element>
                     <dc-qualifier>uri</dc-qualifier>
                     <repeatable>true</repeatable>
-                    <label>External Link</label>
+                    <label>Publication or External Link</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
                     <input-type>onebox</input-type>
                     <hint>
-                        If applicable, enter the URL(s) for the item located elsewhere on the Internet.
-                        If available, please use the DOI (Digital Object Identifier) for the file.
-                        Examples: https://drum.lib.umd.edu/, https://doi.org/10.13016/yhab-ufvn, or
-                        DOI:10.13016/yhab-ufvn.
+                        Enter the DOI (Digital Object Identifier) or other external link to the published version of this research work.
+                    </hint>
+                    <required></required>
+                    <regex>^(https*|DOI):(\/\/)*.*</regex>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>uri</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Related Publication Link</label>
+                    <type-bind>
+                        <!-- Should display only for "Dataset" and "Software" -->
+                        Dataset,
+                        Software
+                    </type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>
+                        Enter the link to any research publication supported by the dataset or software. If available, please use the DOI (Digital Object Identifier) for the publication.
                     </hint>
                     <required></required>
                     <regex>^(https*|DOI):(\/\/)*.*</regex>
@@ -1479,9 +1513,43 @@
                     <dc-element>identifier</dc-element>
                     <dc-qualifier>citation</dc-qualifier>
                     <repeatable>false</repeatable>
-                    <label>Citation</label>
+                    <label>Publication Citation</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
                     <input-type>onebox</input-type>
-                    <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+                    <hint>If the item has been previously published or has a corresponding publication, enter its bibliographic citation.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier>citation</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Related Publication Citation</label>
+                    <type-bind>
+                        <!-- Should display only for "Dataset" and "Software" -->
+                        Dataset,
+                        Software
+                    </type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the standard citation for any research publication supported by the dataset or software.</hint>
                     <required></required>
                 </field>
             </row>
@@ -1492,6 +1560,23 @@
                     <dc-qualifier>ispartofseries</dc-qualifier>
                     <repeatable>true</repeatable>
                     <label>Series/Report No.</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
                     <input-type>series</input-type>
                     <hint>Enter the series and number assigned to this item by your community.</hint>
                     <required></required>
@@ -1505,6 +1590,23 @@
                     <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
                     <repeatable>true</repeatable>
                     <label>Identifiers</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
                     <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
                     <hint>If the item has any identification numbers or codes associated with
                         it, please enter the types and the actual numbers or codes.
@@ -1570,8 +1672,42 @@
                     <dc-qualifier></dc-qualifier>
                     <repeatable>false</repeatable>
                     <label>Description</label>
+                     <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
                     <input-type>textarea</input-type>
                     <hint>Enter any other description or comments in this box.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Methodology Description</label>
+                    <type-bind>
+                        <!-- Should display only for "Dataset" and "Software" -->
+                        Dataset,
+                        Software
+                    </type-bind>
+                    <input-type>textarea</input-type>
+                    <hint>Description of methods used for data collection/generation, processing, analysis, standards, quality-assurance procedures, etc.</hint>
                     <required></required>
                 </field>
             </row>
@@ -2229,6 +2365,8 @@
         </value-pairs>
 
         <!-- Values for the "Types" drop-down -->
+        <!-- Note: When adjusting these values, also adjust "type-bind"
+             attributes in the configuration above. -->
         <value-pairs value-pairs-name="umd_common_types" dc-term="type">
             <pair>
                 <displayed-value>Article</displayed-value>

--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/xmlworkflow/state/actions/DataCommunityCollectionMappingAction.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/xmlworkflow/state/actions/DataCommunityCollectionMappingAction.java
@@ -1,0 +1,135 @@
+package edu.umd.lib.dspace.xmlworkflow.state.actions;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.core.Context;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.workflow.WorkflowException;
+import org.dspace.xmlworkflow.state.Step;
+import org.dspace.xmlworkflow.state.actions.ActionResult;
+import org.dspace.xmlworkflow.state.actions.processingaction.ProcessingAction;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+
+/**
+ * Processing action for mapping items into the "UMD Data Community"
+ * community, if the item type is "Dataset" or "Software"
+ * The item will be mapped into every collection of the Community pointed to by
+ * the "data.community.handle" configuration property.
+ */
+public class DataCommunityCollectionMappingAction extends ProcessingAction {
+    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(
+        DataCommunityCollectionMappingAction.class);
+
+    protected ConfigurationService configurationService;
+    protected HandleService handleService;
+    protected CollectionService collectionService;
+
+    /**
+     * Configuration property containing the handle for the Data Community community
+     */
+    public static String DATA_COMMUNITY_HANDLE_PROPERTY = "data.community.handle";
+
+    @Override
+    public void activate(Context c, XmlWorkflowItem wf)
+            throws SQLException, IOException, AuthorizeException, WorkflowException {
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        handleService = HandleServiceFactory.getInstance().getHandleService();
+        collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    }
+
+    @Override
+    public ActionResult execute(Context c, XmlWorkflowItem wfi, Step step, HttpServletRequest request)
+            throws SQLException, AuthorizeException, IOException, WorkflowException {
+        Item item = wfi.getItem();
+        if (isDataCommunityItem(item)) {
+            log.info("Submitting item '{}' for Data Community", item.getID());
+            mapToDataCommunity(c, item);
+        } else {
+            log.info("Item '{}' not submitted for Data Community", item.getID());
+        }
+        return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME,
+                ActionResult.OUTCOME_COMPLETE);
+    }
+
+    @Override
+    public List<String> getOptions() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Maps the given Item into the collections contained in the
+     * Data Community community.
+     *
+     * @param context the current Context
+     * @param item the Item to map
+     */
+    protected void mapToDataCommunity(Context context, Item item) throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        try {
+            String communityHandle = configurationService.getProperty(
+                DATA_COMMUNITY_HANDLE_PROPERTY);
+
+            if (communityHandle == null) {
+                log.warn("Property '{}' not set, skipping data community mapping for item '{}",
+                    DATA_COMMUNITY_HANDLE_PROPERTY,
+                    item.getHandle());
+                return;
+            }
+
+            Community community = (Community) handleService.resolveToObject(context, communityHandle);
+            if (community == null) {
+                log.warn("Skipping data community mapping for item '{}'. No community for handle '{}'",
+                    item, communityHandle
+                );
+                return;
+            }
+
+            List<Collection> collections = community.getCollections();
+            for (Collection collection : collections) {
+                log.info("Mapping item '{}' to collection '{}'", item.getID(), collection.getID());
+                collectionService.addItem(context, collection, item);
+                collectionService.update(context, collection);
+                itemService.update(context, item);
+            }
+        } finally {
+            context.restoreAuthSystemState();
+        }
+    }
+
+    /**
+     * Returns true if the given Item should be mapped into the Data Community
+     * collection, false otherwise.
+     *
+     * @param item the Item to test
+     * @return true if the given Item should be mapped into the Data Community
+     * collection, false otherwise.
+     */
+    protected boolean isDataCommunityItem(Item item) {
+        List<MetadataValue> valueList = itemService.getMetadata(
+            item, "dc", "type", Item.ANY, Item.ANY);
+        if (!valueList.isEmpty()) {
+            MetadataValue first = valueList.get(0);
+            String value = first.getValue();
+            boolean isDataCommunityItem = "Software".equals(value) || "Dataset".equals(value);
+            log.debug("value={}, isDataCommunityItem={}", value, isDataCommunityItem);
+            return isDataCommunityItem;
+        }
+
+        return false;
+    }
+}

--- a/dspace/modules/additions/src/test/data/dspaceFolder/config/spring/api/workflow-actions.xml
+++ b/dspace/modules/additions/src/test/data/dspaceFolder/config/spring/api/workflow-actions.xml
@@ -104,5 +104,15 @@
         <property name="processingAction" ref="equitableAccessCollectionMappingAPI"/>
         <property name="requiresUI" value="false"/>
     </bean>
+
+    <bean id="dataCommunityCollectionMappingAPI"
+        class="edu.umd.lib.dspace.xmlworkflow.state.actions.DataCommunityCollectionMappingAction"
+        scope="prototype"/>
+
+    <bean id="datacommunitycollectionmappingaction" class="org.dspace.xmlworkflow.state.actions.WorkflowActionConfig" scope="prototype">
+        <constructor-arg type="java.lang.String" value="datacommunitycollectionmappingaction"/>
+        <property name="processingAction" ref="dataCommunityCollectionMappingAPI"/>
+        <property name="requiresUI" value="false"/>
+    </bean>
     <!-- End UMD customization -->
 </beans>

--- a/dspace/modules/additions/src/test/data/dspaceFolder/config/spring/api/workflow.xml
+++ b/dspace/modules/additions/src/test/data/dspaceFolder/config/spring/api/workflow.xml
@@ -213,6 +213,7 @@
         <property name="actions">
             <list>
                 <ref bean="equitableaccesscollectionmappingaction"/>
+                <ref bean="datacommunitycollectionmappingaction"/>
             </list>
         </property>
     </bean>

--- a/dspace/modules/additions/src/test/java/org/dspace/xmlworkflow/state/actions/DataCommunityCollectionMappingIT.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/xmlworkflow/state/actions/DataCommunityCollectionMappingIT.java
@@ -1,0 +1,159 @@
+package org.dspace.xmlworkflow.state.actions;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import edu.umd.lib.dspace.xmlworkflow.state.actions.DataCommunityCollectionMappingAction;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.servicemanager.config.DSpaceConfigurationService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.service.XmlWorkflowService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DataCommunityCollectionMappingIT extends AbstractIntegrationTestWithDatabase {
+    protected XmlWorkflowService xmlWorkflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
+
+    private WorkspaceItem wsi;
+    private Item item;
+
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+
+        // Base community/collection item will be submitted to
+        Community baseCommunity = CommunityBuilder.createCommunity(context)
+                                    .withName("Base Community").build();
+        Collection baseCollection = CollectionBuilder.createCollection(context, baseCommunity)
+                                        .withName("Base Collection")
+                                        .build();
+
+        // Data Community community/collection item may be mapped to
+        Community dataCommunityCommunity = CommunityBuilder.createCommunity(context)
+                                                .withName("UMD Data Community").build();
+        CollectionBuilder.createCollection(context, dataCommunityCommunity)
+                .withName("UMD Data Collection").build();
+
+        // The WorkspaceItem for the workflow
+        wsi = WorkspaceItemBuilder.createWorkspaceItem(context, baseCollection)
+            .withTitle("Test item")
+            .withIssueDate("2019-03-06")
+            .build();
+
+        // The actual Item
+        item = wsi.getItem();
+
+        // Use handle of dataCommunityCommunity object as DATA_COMMUNITY_HANDLE_PROPERTY value
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        configurationService.setProperty(
+            DataCommunityCollectionMappingAction.DATA_COMMUNITY_HANDLE_PROPERTY,
+            dataCommunityCommunity.getHandle()
+        );
+
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void itemNotAdded_WhenHandlePropertyNotConfigured() throws Exception {
+        // Clear the DATA_COMMUNITY_HANDLE_PROPERTY
+        DSpaceConfigurationService configService =
+            (DSpaceConfigurationService) DSpaceServicesFactory.getInstance().getConfigurationService();
+        configService.clearConfig(
+            DataCommunityCollectionMappingAction.DATA_COMMUNITY_HANDLE_PROPERTY);
+
+        submitItemWithType("Dataset");
+        assertThat(getCollectionNames(item), not(hasItem("UMD Data Collection")));
+    }
+
+    @Test
+    public void itemNotAdded_WhenCommunityDoesNotExit() throws Exception {
+        DSpaceConfigurationService configService =
+            (DSpaceConfigurationService) DSpaceServicesFactory.getInstance().getConfigurationService();
+        configService.setProperty(
+            DataCommunityCollectionMappingAction.DATA_COMMUNITY_HANDLE_PROPERTY,
+            "community_does_not_exist"
+        );
+
+        submitItemWithType("Dataset");
+        assertThat(getCollectionNames(item), not(hasItem("UMD Data Collection")));
+    }
+
+
+    @Test
+    public void itemAdded_WhenItemType_IsDataset() throws Exception {
+        submitItemWithType("Dataset");
+        assertThat(getCollectionNames(item), hasItem("UMD Data Collection"));
+    }
+
+    @Test
+    public void itemAdded_WhenItemType_IsSoftware() throws Exception {
+        submitItemWithType("Software");
+        assertThat(getCollectionNames(item), hasItem("UMD Data Collection"));
+    }
+
+    @Test
+    public void itemNotAdded_WhenItemType_AnythingElse() throws Exception {
+        submitItemWithType("Article");
+        assertThat(getCollectionNames(item), not(hasItem("UMD Data Collection")));
+    }
+
+    @Test
+    public void itemNotAdded_WhenItemType_IsNull() throws Exception {
+        submitItemWithType(null);
+        assertThat(getCollectionNames(item), not(hasItem("UMD Data Collection")));
+    }
+
+    @Test
+    public void itemNotAdded_WhenItemType_IsEmptyString() throws Exception {
+        submitItemWithType("");
+        assertThat(getCollectionNames(item), not(hasItem("UMD Data Collection")));
+    }
+
+    @Test
+    public void itemNotAdded_WhenSubmissionValue_IsSomeOtherString() throws Exception {
+        submitItemWithType("random string");
+        assertThat(getCollectionNames(item), not(hasItem("UMD Data Collection")));
+    }
+
+    /**
+     * Sets the item type value on the item, and activates workflow
+     *
+     * @param itemType the String representing the item type, drawn from the
+     * umd_common_types "stored-value" entries in dspace/config/submission-forms.xml
+     */
+    protected void submitItemWithType(String itemType) throws Exception {
+        ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+        itemService.setMetadataSingleValue(
+            context, item, "dc", "type", null, null, itemType);
+
+        xmlWorkflowService.startWithoutNotify(context, wsi);
+    }
+
+    /**
+     * Returns a List of collection names (from "getCollections()") for the
+     * given Item.
+     *
+     * @param item the Item to return the collection names of
+     */
+    protected List<String> getCollectionNames(Item item) {
+        return item.getCollections().stream().map(c -> c.getName()).collect(toList());
+    }
+}


### PR DESCRIPTION
Uses the DSpace 7 "type-bind" functionality to dynamically
modify the submission form to display different
fields (and different labels/hints for fields), based on whether
or not the "Type" field for the item is "Dataset" or "Software".

Also added a workflow action to map the item to the collections
in the "UMD Data Community" community (determined by
the "data.community.handle" property in the "dspace/config/local.cfg"
file), if the type is "Dataset" or "Software".

https://umd-dit.atlassian.net/browse/LIBDRUM-682