### PR TITLE
LIBDRUM-678. Embargo policy updates

### DIFF
--- a/Dockerfile.dev-additions
+++ b/Dockerfile.dev-additions
@@ -45,7 +45,19 @@ RUN ant init_installation update_configs update_code update_webapps
 FROM tomcat:9-jdk${JDK_VERSION}
 ENV DSPACE_INSTALL=/dspace
 ENV TOMCAT_INSTALL=/usr/local/tomcat
-# Copy the /dspace directory from 'ant_build' containger to /dspace in this container
+
+# Add csh and Perl libraries for scripts in /dspace/bin
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        csh \
+        libgetopt-complete-perl \
+        libconfig-properties-perl
+
+# Create the directories needed for Proquest ETD loading
+RUN mkdir -p $DSPACE_INSTALL/proquest/incoming $DSPACE_INSTALL/proquest/processed \
+             $DSPACE_INSTALL/proquest/csv $DSPACE_INSTALL/proquest/marc
+
+# Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 # Enable the AJP connector in Tomcat's server.xml
 # NOTE: secretRequired="false" should only be used when AJP is NOT accessible from an external network. But, secretRequired="true" isn't supported by mod_proxy_ajp until Apache 2.5

--- a/dspace/docs/DrumEmbargoAndAccessRestrictions.md
+++ b/dspace/docs/DrumEmbargoAndAccessRestrictions.md
@@ -1,0 +1,158 @@
+# DRUM Embargo and Access Restrictions
+
+## Introduction
+
+This page describes the DRUM Embargo functionality and other access
+restrictions, as of DSpace 7.
+
+## Useful Resources
+
+* <https://wiki.lyrasis.org/display/DSDOC7x/Embargo>
+* <https://wiki.lyrasis.org/display/DSDOC7x/Authentication+Plugins#AuthenticationPlugins-IPAuthentication>
+
+## Stock DSpace Embargo Functionality
+
+**Note:** The DSpace documentation discusses embargoes for both items and
+bitstreams. In the DRUM configuration, only bitstreams are embargoed, so this
+document will use "bitstream" throughout.
+
+DSpace embargoes a bitstream solely through the resource policies on that
+bitstream.
+
+As described in the [DSpace documentation](https://wiki.lyrasis.org/display/DSDOC7x/Embargo):
+
+> An embargo is a temporary access restriction placed on metadata or bitstreams
+> (i.e. files). Its scope or duration may vary, but the fact that it eventually
+> expires is what distinguishes it from other content restrictions.
+
+Therefore, there is no explicit representation of an embargo in the database,
+it is simply an emergent result based on the resource policies of the bitstream,
+the user, and the current date.
+
+The resource policy for an embargo typically consists of setting an
+"Anonymous READ" policy (a policg for the "Anonymous" group with "READ"
+permission) that has a "Start Date" in the future. Once the date in the
+"Start Date" is reached, anyone can download the bitstream. For bitstreams that
+are permanently embargoed, an "Anonymous READ" policy is simply not created.
+
+The DSpace Angular front-end shows a "lock" icon next to the download link. The
+display of this icon is controlled by whether or not the user has "READ"
+permission for the bitstream. If the user clicks the link, the stock DSpace
+functionality is:
+
+* If the user is not logged in, send them to a login page
+* If the user is logged in, show a "Forbidden" page
+
+## IP Address-based Download Restrictions
+
+Another stock DSpace mechanism for restricting bitstream downloads is IP Address
+authentication, see:
+
+<https://wiki.lyrasis.org/display/DSDOC7x/Authentication+Plugins#AuthenticationPlugins-IPAuthentication>
+
+This is currently used to enforce "on-campus" access to bitstreams, via the
+"Campus" group.
+
+This is not really an embargo, but intersects with the embargo functionality
+when it comes to displaying the "Restricted Access" page (see below).
+
+A bitstream that is that available to the user due to an IP address restriction
+will show the "lock" icon next to the download link, as the user does not have
+"READ" permission for the bitstream.
+
+## Embargo Functionality in DRUM
+
+UMD began embargoing items before the current DSpace embargo functionality
+existed. The following functionality is currently supported:
+
+* Automatically add embargo terms to "ETD" bitstreams uploaded from ProQuest.
+* Display a list of embargoed items, with embargo lift dates
+* Display a "Restricted Access" marker below the download link, if the bitstream
+  is embargoed. This marker is displayed for all users (even those who can
+  download the bitstream).
+* A "Restricted Access" page is shown if a user attempts to download a bitstream
+  for which they do not have a "READ" resource policy. Different messages
+  are shown based on the user's login status, and (for anonymous users) whether
+  or not the bitstream has an embargo lift date.
+
+This UMD-specific functionality is supported by adding a resource policy a group
+of "ETD Embargo" to the bitstreams to be embargoed. Permanently embargoed items
+have an "ETD Embargo READ" policy without an "End Date" (and no
+"Anonymous READ" policy). Embargoes that eventually end have an
+"ETD Embargo READ" policy with an "End Date" corresponding to the "Start Date"
+of the "Anonymous READ" policy.
+
+There is nothing in the current system that enforces this pairing of
+"ETD Embargo READ" and "Anonymous Embargo READ" resource policies.
+Resource policies can be manually added/edited by administrators, and the
+system simply relies on those administrators maintaining both policies.
+
+### ETD Loader
+
+When ingesting ETD items from ProQuest, the bitstreams will either have no
+embargo, or a specific date for lifting the embargo. For embargoed items, the
+ETD loaded  automatically adds both policies.
+
+### Embargo List
+
+The "Embargo List" functionality lists all items that have *any* bitstream
+with an "ETD Embargo" resource policy whose "End Date" is not in the past.
+This means an item may appear in the list even if its "primary bitstream"
+(the one a user would typically download) is not embargoed.
+
+Note that the "Embargo List" only uses "ETD Embargo" resource policies. It
+does not use any "Anonymous READ" policies (or lack thereof) associated with
+the item's bitstreams. The "End Date" column in the table uses the "End Date"
+field in the "ETD Embargo" resource policy.
+
+### Restricted Access Marker
+
+A "(RESTRICTED ACCESS)" marker is shown below the download link for embargoed
+bitstreams. This marker is displayed for all users (even those who can download
+the bitstream).
+
+This marker is separate from the stock DSpace "lock" icon that appears to the
+left of the download link. The presence of the "lock" icon indicates that the
+user cannot download the bitstream (for example, if there is a "Campus" IP
+address restriction on the bitstream, and the user is not on campus).
+
+The primary intention of the "(RESTRICTED ACCESS) marker is to enable
+administrators to easily see that a bitstream is embargoed, and relies solely
+on the "ETD Embargo" resource policy.
+
+### Restricted Access Page
+
+Attempting to download a bitstream to which the user does not have "READ"
+permission (either due to an embargo, or some other factor) will result in
+a "Restricted Access" page being shown. The page shows different messages
+based on:
+
+* Whether the user is logged in - this can happen, for example, if a bitstream
+  has been restricted to on-campus IP addresses through a "Campus" group
+  resource policy.
+* For anoynmous users, whether the embargo has a lift date
+
+This functionality relies on the stock DSpace resource policies to determine
+if a user has "READ" permission to the bitstream. The "ETD Embargo" resource
+policy is only used to determine the embargo lift date.
+
+## Expected Functionality
+
+The following table summarizes the expected behavior in the various scenarios
+involving embargoes and "Campus" IP access restrictions:
+
+| Situation                        | Anonymous                 | Logged-in User            | Administrator             |
+| -------------------------------- | ------------------------- | ------------------------- | ------------------------- |
+| No Embargo                       | No lock/No RAM/Can Access | No lock/No RAM/Can Access | No lock/No RAM/Can Access |
+| Embargo - Past Lift Date         | No lock/No RAM/Can Access | No lock/No RAM/Can Access | No lock/No RAM/Can Access |
+| Embargo - Future Lift Date       | Lock/RAM/No Access        | Lock/RAM/No Access        | No lock/RAM/Can Access    |
+| Embargo - Forever                | Lock/RAM/No Access        | Lock/RAM/No Access        | No lock/RAM/Can Access    |
+| "Campus" Restricted - On-campus  | No Lock/No RAM/No Access  | No Lock/No RAM/No Access  | No lock/No RAM/Can Access |
+| "Campus" Restricted - Off-campus | Lock/No RAM/No Access     | Lock/No RAM/No Access     | No lock/No RAM/Can Access |
+
+Where:
+
+* "lock" - whether or not the "lock" icon is displayed
+* "RAM" - whether or not the "Remote Access" text marker is shown beneath the
+   download link
+* "Access" - whether or not the user can actually download the bitstream.

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/converter/BitstreamConverter.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/converter/BitstreamConverter.java
@@ -1,0 +1,127 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CheckSumRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.eperson.Group;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * This is the converter from/to the Bitstream in the DSpace API data model and the REST data model
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Component
+public class BitstreamConverter extends DSpaceObjectConverter<Bitstream, BitstreamRest> {
+    @Autowired(required = true)
+    protected ResourcePolicyService resourcePolicyService;
+
+    @Override
+    public BitstreamRest convert(org.dspace.content.Bitstream obj, Projection projection) {
+        BitstreamRest b = super.convert(obj, projection);
+        b.setSequenceId(obj.getSequenceID());
+        List<Bundle> bundles = null;
+        try {
+            bundles = obj.getBundles();
+        } catch (SQLException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
+        }
+        if (bundles != null && bundles.size() > 0) {
+            b.setBundleName(bundles.get(0).getName());
+        }
+        CheckSumRest checksum = new CheckSumRest();
+        checksum.setCheckSumAlgorithm(obj.getChecksumAlgorithm());
+        checksum.setValue(obj.getChecksum());
+        b.setCheckSum(checksum);
+        b.setSizeBytes(obj.getSizeBytes());
+
+        // UMD Customization
+        b.setEmbargoRestriction(getEmbargoRestriction(obj));
+        // End UMD Customization
+        return b;
+    }
+
+    @Override
+    protected BitstreamRest newInstance() {
+        return new BitstreamRest();
+    }
+
+    @Override
+    public Class<Bitstream> getModelClass() {
+        return Bitstream.class;
+    }
+
+    // UMD Customization
+
+    /**
+     * Returns the "ETD Embargo" ResourcPolicy for the given DSpaceObject,
+     * or null if there is no such policy.
+     *
+     * @param object the DSpaceObject to check for an ETD Embargo
+     * @return the "ETD Embargo" ResourcPolicy for the given DSpaceObject,
+     * or null if there is no such policy.
+     */
+    protected ResourcePolicy getEtdEmbargo(DSpaceObject object) {
+        List<ResourcePolicy> policies = object.getResourcePolicies();
+
+        for (ResourcePolicy policy: policies) {
+            Group group = policy.getGroup();
+            if (group != null) {
+                if (group.getName().equals("ETD Embargo")) {
+                    return policy;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns one of the following Strings, based on whether the given
+     * DSpace object has an embargo-based restriction:
+     *
+     * <ul>
+     * <li> A date string (in "yyyy-MM-dd" format) - The lift date of the embargo
+     * <li> "FOREVER" - the embargo never ends
+     * <li> "NONE" - there is no embargo (or the embargo lift date has passed)
+     * </ul>
+     *
+     * @param object the DSpaceObject to get the embargo restriction of. Should
+     * not be null.
+     */
+    protected String getEmbargoRestriction(DSpaceObject object) {
+        ResourcePolicy etdEmbargoPolicy = getEtdEmbargo(object);
+
+        if ((etdEmbargoPolicy != null) && (resourcePolicyService.isDateValid(etdEmbargoPolicy))) {
+            Date liftDate = etdEmbargoPolicy.getEndDate();
+            if (liftDate != null) {
+                return DateFormatUtils.format(liftDate, "yyyy-MM-dd");
+            } else {
+                return "FOREVER";
+            }
+        }
+
+        return "NONE";
+    }
+
+    // End UMD Customization
+}

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -1,0 +1,127 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
+/**
+ * The Bitstream REST Resource
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@LinksRest(links = {
+        @LinkRest(
+                name = BitstreamRest.BUNDLE,
+                method = "getBundle"
+        ),
+        @LinkRest(
+                name = BitstreamRest.FORMAT,
+                method = "getFormat"
+        ),
+        @LinkRest(
+                name = BitstreamRest.THUMBNAIL,
+                method = "getThumbnail"
+        )
+})
+public class BitstreamRest extends DSpaceObjectRest {
+    public static final String PLURAL_NAME = "bitstreams";
+    public static final String NAME = "bitstream";
+    public static final String CATEGORY = RestAddressableModel.CORE;
+
+    public static final String BUNDLE = "bundle";
+    public static final String FORMAT = "format";
+    public static final String THUMBNAIL = "thumbnail";
+
+    private String bundleName;
+
+    private Long sizeBytes;
+    private CheckSumRest checkSum;
+    // sequenceId is READ_ONLY because it is assigned by the ItemService (as it must be unique within an Item)
+    @JsonProperty(access = Access.READ_ONLY)
+    private Integer sequenceId;
+
+    public String getBundleName() {
+        return bundleName;
+    }
+
+    public void setBundleName(String bundleName) {
+        this.bundleName = bundleName;
+    }
+
+    public Long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(Long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+    }
+
+    public CheckSumRest getCheckSum() {
+        return checkSum;
+    }
+
+    public void setCheckSum(CheckSumRest checkSum) {
+        this.checkSum = checkSum;
+    }
+
+    public Integer getSequenceId() {
+        return sequenceId;
+    }
+
+    public void setSequenceId(Integer sequenceId) {
+        this.sequenceId = sequenceId;
+    }
+
+    @Override
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getType() {
+        return NAME;
+    }
+
+    // UMD Customization
+
+    /**
+     * A String representing whether (and how long) this bitstream is embargoed.
+     */
+    public String embargoRestriction;
+
+    /**
+     * Returns one of the following Strings, based on whether the given
+     * DSpace object has an embargo-based restriction:
+     *
+     * <ul>
+     * <li> A date string (in "yyyy-MM-dd" format) - The lift date of the embargo
+     * <li> "FOREVER" - the embargo never ends
+     * <li> "NONE" - there is no embargo (or the embargo lift date has passed)
+     * </ul>
+     *
+     * @return a String indicating whether (and how long) this bitstream is
+     * embargoed
+     */
+    public String getEmbargoRestriction() {
+        return embargoRestriction;
+    }
+
+    /**
+     * Sets whether (and how long) this bitstream is embargoed
+     *
+     * @param embargoRestriction the String indicating the embargo restriction,
+     * if any.
+     */
+    public void setEmbargoRestriction(String embargoRestriction) {
+        this.embargoRestriction = embargoRestriction;
+    }
+
+    // End UMD Customization
+}

--- a/dspace/modules/server/src/test/java/org/dspace/app/rest/converter/BitstreamConverterIT.java
+++ b/dspace/modules/server/src/test/java/org/dspace/app/rest/converter/BitstreamConverterIT.java
@@ -1,0 +1,106 @@
+package org.dspace.app.rest.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.eperson.Group;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration test for BitstreamConverter
+ *
+ * Using an integration test of ResourcePolicyService dependency
+ */
+public class BitstreamConverterIT extends AbstractControllerIntegrationTest {
+    @Autowired
+    private ConverterService converterService;
+
+    private ResourcePolicy etdEmbargoPolicy;
+    private ResourcePolicy otherPolicy;
+    private Bitstream mockBitstream;
+    private BitstreamConverter converter;
+    private SimpleDateFormat asDate;
+
+    @Before
+    public void setup() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        Group etdEmbargoGroup = GroupBuilder.createGroup(context).withName("ETD Embargo").build();
+        etdEmbargoPolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+                            .withGroup(etdEmbargoGroup).build();
+
+        Group otherGroup = GroupBuilder.createGroup(context).withName("Other").build();
+        otherPolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+                        .withGroup(otherGroup).build();
+
+        mockBitstream = mock(Bitstream.class);
+        context.restoreAuthSystemState();
+
+        // Need to retrieve BitstreamConverter via converter service so that
+        // all the Autowired resources in the converter get initialized.
+        // This seems to be due to ConverterService being responsible for
+        // autowiring the converters (see comment in DSpaceObjectConverter)
+        converter = (BitstreamConverter) ((DSpaceObjectConverter)
+             converterService.getConverter(Bitstream.class));
+        asDate = new SimpleDateFormat("yyyy-MM-dd");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void getEmbargoRestriction_throwsNullPointerExceptionWhenBitstreamIsNull() {
+        // Method assumes that provided DSpaceObject is always non-null.
+        converter.getEmbargoRestriction(null);
+
+    }
+
+    @Test
+    public void testgetEmbargoRestriction_ReturnsNone_WhenNoResourcePolicies() {
+        assertEquals("NONE", converter.getEmbargoRestriction(mockBitstream));
+    }
+
+    @Test
+    public void testgetEmbargoRestriction_ReturnsNone_WhenNoEtdEmbargoPolicy() {
+        when(mockBitstream.getResourcePolicies()).thenReturn(List.of(otherPolicy));
+        assertEquals("NONE", converter.getEmbargoRestriction(mockBitstream));
+    }
+
+    @Test
+    public void testgetEmbargoRestriction_ReturnsNone_WhenEtdEmbargoPolicyWithEndDateInPast() throws Exception {
+        etdEmbargoPolicy.setEndDate(asDate.parse("1972-12-03"));
+        when(mockBitstream.getResourcePolicies()).thenReturn(List.of(etdEmbargoPolicy));
+
+        assertEquals("NONE", converter.getEmbargoRestriction(mockBitstream));
+    }
+
+    @Test
+    public void testgetEmbargoRestriction_ReturnsEndDate_WhenEtdEmbargoPolicyWithEndDateInFuture() throws Exception {
+        long oneYearInMillis = 365l * 24 * 60 * 60 * 1000;
+        Date futureDate = new Date(System.currentTimeMillis() + oneYearInMillis); // One year (approx.) in the future
+
+        String expectedDateStr = asDate.format(futureDate);
+        etdEmbargoPolicy.setEndDate(futureDate);
+        when(mockBitstream.getResourcePolicies()).thenReturn(List.of(etdEmbargoPolicy));
+
+        assertEquals(expectedDateStr, converter.getEmbargoRestriction(mockBitstream));
+    }
+
+    @Test
+    public void testgetEmbargoRestriction_ReturnsForever_WhenEtdEmbargoPolicyHasNullEndDate() throws Exception {
+        etdEmbargoPolicy.setEndDate(null);
+        when(mockBitstream.getResourcePolicies()).thenReturn(List.of(etdEmbargoPolicy));
+
+        assertEquals("FOREVER", converter.getEmbargoRestriction(mockBitstream));
+    }
+}


### PR DESCRIPTION
Modified the "Dockerfile.dev-additions" to add the "csh" and Perl
dependencies used by the "load-etd"/"load-etd-nightly" scripts, to
simplify testing/development of ETD loader functionality. These
libraries are loaded by the "Dockerfile" used for production, so this
makes the development environment a little more similar to production.

Added an "embargoRestriction" field to the  "BitstreamRest" object
passed between the back-end and frontend. The field is a simple string
that contains:

* "NONE" - no embargo (or embargo on item has been lifted)
* "FOREVER" - the embargo never ends
* A date (in yyyy-MM-dd) format, indicating the embargo lift date

Modified the "BitstreamConverter" to populate the "embargoRestriction"
field, based on any "ETD Embargo" resource policies on the bitstream.

Added "dspace/docs/DrumEmbargoAndAccessRestrictions.md" to record
information about the ETD Embargo functionality and other access
restrictions that affect the downloading of bitstreams.

Also added "/dspace/proquest" directory and subdirectories used by
the scripts.

https://umd-dit.atlassian.net/browse/LIBDRUM-678
