### PR TITLE
LIBDRUM-747. Disabled embargo functionality on submission form.

### DIFF
--- a/dspace/config/spring/api/access-conditions.xml
+++ b/dspace/config/spring/api/access-conditions.xml
@@ -9,31 +9,35 @@
 		<property name="metadata" value="bitstream-metadata" />
         <property name="options">
             <list>
-                <ref bean="openAccess"/>
+                <!-- UMD Customization -->
+                <!-- Commenting out to disable ability of user to set embargo -->
+                <!-- <ref bean="openAccess"/>
                 <ref bean="lease"/>
                 <ref bean="embargoed" />
-                <ref bean="administrator"/>
+                <ref bean="administrator"/> -->
+                <!-- End UMD Customization -->
                 <!-- <ref bean="networkAdministration"/> -->
             </list>
         </property>
     </bean>
 
-  <!-- Customization for LIBDRUM-684 -->
+  <!-- UMD Customization -->
   <bean id="uploadConfigurationOptional" class="org.dspace.submit.model.UploadConfiguration">
     <property name="name" value="upload"/>
     <property name="metadata" value="bitstream-metadata" />
     <property name="options">
       <list>
-          <ref bean="openAccess"/>
+          <!-- Commenting out to disable ability of user to set embargo -->
+          <!-- <ref bean="openAccess"/>
           <ref bean="lease"/>
           <ref bean="embargoed" />
-          <ref bean="administrator"/>
+          <ref bean="administrator"/> -->
            <!-- <ref bean="networkAdministration"/> -->
       </list>
     </property>
     <property name="required" value="false"/>
   </bean>
-  <!-- Customization for LIBDRUM-684 -->
+  <!-- UMD Customization -->
 
     <bean id="openAccess" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>


### PR DESCRIPTION
Displayed the ability of a user to set an embargo (access restriction) on an uploaded file in the submission form by removing all of the access restriction options in the "access-conditions.xml" file.

This was done in accordance with the instructions in the DSpace 7 documentation:

https://wiki.lyrasis.org/display/DSDOC7x/Submission+User+Interface#SubmissionUserInterface-Modifyingaccessconditions(embargo,etc.)presentedforBitstreams

> options (Required, but can be empty): list of all
> "AccessConditionOption" beans to enable. This list will be shown to
> the user to let them select which access restrictions to place on each
> bitstream. NOTE: To disable the ability to select bitstream access
> restrictions, comment out all <ref> tags to create an empty list of
> options.

https://umd-dit.atlassian.net/browse/LIBDRUM-747
