### PR TITLE
LIBDRUM-763. Implement UMD OpenSearch endpoints

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -405,8 +405,3 @@ data.community.handle = 1903/27669
 # Equitable Access Policy
 # The handle for the "Equitable Access Policy" community
 equitable_access_policy.community.handle = 1903/29474
-
-# Expose "dspace.name" and "dspace.baseUrl" properties so it is available for
-# JSON-LD Website. See dspace/config/modules/rest.cfg
-rest.properties.exposed = dspace.name
-rest.properties.exposed = dspace.baseUrl

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -46,6 +46,14 @@ rest.properties.exposed = google.recaptcha.key.site
 rest.properties.exposed = google.recaptcha.version
 rest.properties.exposed = google.recaptcha.mode
 
+# UMD Customization
+#
+# Expose "dspace.name" and "dspace.baseUrl" properties so it is available for
+# JSON-LD Website. See dspace/config/modules/rest.cfg
+rest.properties.exposed = dspace.name
+rest.properties.exposed = dspace.baseUrl
+# End UMD Customization
+
 #---------------------------------------------------------------#
 # These configs are used by the deprecated REST (v4-6) module   #
 #---------------------------------------------------------------#

--- a/dspace/docs/DrumOAI-PMH.md
+++ b/dspace/docs/DrumOAI-PMH.md
@@ -1,0 +1,73 @@
+# DRUM OAI-PMH
+
+## Introduction
+
+This page describes the DRUM OAI-PMH functionality, as of DSpace 7. See
+<https://wiki.lyrasis.org/display/DSDOC7x/OAI+2.0+Server>
+for the DSpace documentation on the OAI-PMG server functionality.
+
+This document focuses on the customizations made for DRUM.
+
+## DRUM OAI-PMH Endpoints
+
+The <https://opendata.lib.umd.edu/services.html#drum> website documents the
+expected endpoint for the DRUM OAI-PMH server, with example searches.
+
+The main endpoint is `<SERVER_URL>/oai/request`.
+
+In the interest of stability, "/oai/request" URL path should be used as long
+as feasible for accessing the DRUM OAI-PMH functionality.
+
+## DSpace 7 Defaults
+
+In DSpace 6, the OAI-PMH endpoint was the "/oai/request" URL path.
+
+In DSpace 7, the front-end and back-end were split into two different components
+with the OAI-PMH functionality being provided by the back-end component.
+
+The demo DSpace website (see <https://wiki.lyrasis.org/display/DSDOC7x/DSpace+7+Demo+Quick+Start>)
+handled this split with two separate URLS:
+
+* <https://demo7.dspace.org/home> for the DSpace Angular front-end
+* <https://api7.dspace.org/server/> for the DSpace back-end
+
+In the local development environment, these correspond to the Angular front-end
+running on <http://localhost:4000/> and the DSpace back-end running on
+<http://localhost:8080/server/>.
+
+## DRUM Server Kubernetes Changes
+
+### Kubernetes Ingress Nginx Rewrites
+
+For DRUM, we use a single URL (<https://drum.lib.umd.edu/> for production) for
+both the front-end and back-end. The Kuberenetes Ingress configuration is set
+up to send the "/server" URL path to the DSpace back-end, and any other URL path
+to the Angular front-end.
+
+This means that for DRUM, the default OAI-PMH URL path is "/server/oai/request".
+
+To make available the "/oai/request" URL path for OAI-PHM queries, the
+Nginx configuration in the Ingress configuration was modified to alias the
+following URL paths to the DSpace 7 default path:
+
+* /oai -> /server/oai
+* /webjars -> /server/webjars
+
+The "/webjars" alias is needed because the stock DSpace OAI-PMH HTML files use
+relative URL addresses ('../webjars') to retrieve JavaScript and CSS resources
+needed for the OAI-PMH functionality.
+
+### Kubernetes Configuration Properties
+
+The following line was added to the "local.cfg" file in each of the Kubernetes
+overlays to modify the "oai.url" property, so that the "/oai" endpoint would be
+referenced in the OAI-PMH output, instead of the "/server/oai" endpoint:
+
+```text
+oai.url = ${dspace.url}/${oai.path}
+```
+
+## Local Development Endpoints
+
+For local development, the OAI-PMH endpoint remains at the DSpace 7 default
+of <http://localhost:8080/server/oai>.

--- a/dspace/docs/DrumOpenSearch.md
+++ b/dspace/docs/DrumOpenSearch.md
@@ -1,0 +1,101 @@
+# DRUM OpenSearch
+
+## Introduction
+
+This page describes the DRUM OpenSearch functionality, as of DSpace 7. See
+
+* <https://wiki.lyrasis.org/display/DSDOC7x/Business+Logic+Layer#BusinessLogicLayer-OpenSearchSupport>
+* <https://wiki.lyrasis.org/display/DSDOC7x/Configuration+Reference#ConfigurationReference-OpenSearchSupport>
+<https://wiki.lyrasis.org/display/DSDOC7x/OAI+2.0+Server>
+
+for the DSpace documentation on the OpenSearch server functionality.
+
+This document focuses on the customizations made for DRUM.
+
+## DRUM OpenSearch Endpoints
+
+The <https://opendata.lib.umd.edu/services.html#drum> website documents the
+expected endpoint for the DRUM OpenSearch server, with example searches.
+
+The main endpoint is `<SERVER_URL>/open-search/discover`.
+
+In the interest of stability, "/open-search/discover" URL path should be used as
+long as feasible for accessing the DRUM OpenSearch functionality.
+
+## DSpace 7 Defaults
+
+In DSpace 6, the OpenSearch endpoint was the "/open-search/discover" URL path.
+
+In DSpace 7, the front-end and back-end were split into two different components
+with the OpenSearch functionality being provided by the back-end component.
+
+The demo DSpace website (see <https://wiki.lyrasis.org/display/DSDOC7x/DSpace+7+Demo+Quick+Start>)
+handled this split with two separate URLS:
+
+* <https://demo7.dspace.org/home> for the DSpace Angular front-end
+* <https://api7.dspace.org/server/> for the DSpace back-end
+
+In the local development environment, these correspond to the Angular front-end
+running on <http://localhost:4000/> and the DSpace back-end running on
+<http://localhost:8080/server/>.
+
+In a stock DSpace 7, the OpenSearch functionality is provided on the
+"/server/opensearch/search" URL path, with an OpenSearch service description
+at the "/server/opensearch/servce" URL path.
+
+## DRUM Server Kubernetes Changes
+
+### Kubernetes Ingress Nginx Rewrites
+
+For DRUM, we use a single URL (<https://drum.lib.umd.edu/> for production) for
+both the front-end and back-end. The Kuberenetes Ingress configuration is set
+up to send the "/server" URL path to the DSpace back-end, and any other URL path
+to the Angular front-end.
+
+This means that for DRUM, the default OpenSearch URL path is
+"/server/opensearch/search".
+
+To make available the "/open-search/discover" URL path for OpenSearch queries,
+the Nginx configuration in the Ingress configuration was modified to alias the
+following URL paths to the DSpace 7 default path:
+
+* /open-search/discover -> /server/opensearch/search
+* /open-search -> /server/opensearch
+
+### Kubernetes Configuration Properties
+
+To ensure that the OpenSearch output includes the correct server URL and aliased
+URL paths, the following two properties are configurated in the "local.cfg"
+file of each Kubernetes overlay:
+
+```text
+opensearch.server.url = ${dspace.url}
+websvc.opensearch.svccontext = open-search/discover
+```
+
+The "opensearch.server.url" property is a UMD custom property (used in the
+customized "dspace/modules/additions/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java"
+file), to ensure that that Angular front-end URL, not the DSpace back-end
+URL, is used in the OpenSearch output.
+
+The "websvc.opensearch.svccontext" property is configured to ensure that the
+the "/open-search/discover" endpoint is be referenced in the
+OpenSearch output, instead of the default "/server/opensearch/search" endpoint.
+
+```text
+websvc.opensearch.svccontext = open-search/discover
+```
+
+**Note:** Based on the DSpace 7 documentation, it seems as if the
+"websvc.opensearch.svccontext" property should change the default DSpace 7
+OpenSearch endpoint, but does not. The "opensearch/search" endpoint is clearly
+hard-coded in the "dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java"
+file.
+
+## Local Development Endpoints
+
+For local development, the OpenSearch endpoints remain at the DSpace 7 defaults
+of:
+
+* <http://localhost:8080/server/opensearch/search>
+* <http://localhost:8080/server/opensearch/service>

--- a/dspace/modules/additions/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -1,0 +1,298 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.rometools.modules.opensearch.OpenSearchModule;
+import com.rometools.modules.opensearch.entity.OSQuery;
+import com.rometools.modules.opensearch.impl.OpenSearchModuleImpl;
+import com.rometools.rome.io.FeedException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.service.OpenSearchService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.discovery.IndexableObject;
+import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.output.DOMOutputter;
+import org.jdom2.output.XMLOutputter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.w3c.dom.Document;
+
+/**
+ * Utility Class with static methods for producing OpenSearch-compliant search results,
+ * and the OpenSearch description document.
+ * <p>
+ * OpenSearch is a specification for describing and advertising search-engines
+ * and their result formats. Commonly, RSS and Atom formats are used, which
+ * the current implementation supports, as is HTML (used directly in browsers).
+ * NB: this is baseline OpenSearch, no extensions currently supported.
+ * </p>
+ * <p>
+ * The value of the "scope" parameter should either be absent (which means no
+ * scope restriction), or the handle of a community or collection.
+ * </p>
+ *
+ * @author Richard Rodgers
+ */
+public class OpenSearchServiceImpl implements OpenSearchService {
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(OpenSearchServiceImpl.class);
+
+    // Namespaces used
+    protected final String osNs = "http://a9.com/-/spec/opensearch/1.1/";
+
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
+
+    @Autowired(required = true)
+    protected HandleService handleService;
+
+    protected OpenSearchServiceImpl() {
+    }
+
+    @Override
+    public List<String> getFormats() {
+        List<String> formats = new ArrayList<>();
+        // read formats only if enabled
+        if (isEnabled()) {
+            String[] fmts = configurationService.getArrayProperty("websvc.opensearch.formats");
+            formats = Arrays.asList(fmts);
+        }
+        return formats;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return configurationService.getBooleanProperty("websvc.opensearch.enable");
+    }
+
+    /**
+     * Get base search service URL (websvc.opensearch.svccontext)
+     */
+    protected String getBaseSearchServiceURL() {
+        // UMD Customization
+        // In production, we run both the front-end and back-end on the same
+        // hostname, with URL rewrite rules to send OpenSearch queries to the
+        // DSpace back-end. Thus, we need to use the "dspace.ui.url" in
+        // production, while maintaining use of the "dspace.server.url" for
+        // local development.
+        //
+        // Handling this by introducting an "opensearch.server.url" property
+        // which can be defined in production, but default back to
+        // "dspace.server.url" if not present.
+        String dspaceServerUrl = configurationService.getProperty("dspace.server.url");
+        String openSearchServerUrl = configurationService.getProperty(
+            "opensearch.server.url", dspaceServerUrl);
+        return openSearchServerUrl + "/" +
+            configurationService.getProperty("websvc.opensearch.svccontext");
+        // End UMD Customization
+    }
+
+    /**
+     * Get base search UI URL (websvc.opensearch.uicontext)
+     */
+    protected String getBaseSearchUIURL() {
+        return configurationService.getProperty("dspace.ui.url") + "/" +
+            configurationService.getProperty("websvc.opensearch.uicontext");
+    }
+
+    @Override
+    public String getContentType(String format) {
+        return "html".equals(format) ? "text/html" :
+            "application/" + format + "+xml; charset=UTF-8";
+    }
+
+    @Override
+    public Document getDescriptionDoc(String scope) throws IOException {
+        return jDomToW3(getServiceDocument(scope));
+    }
+
+    @Override
+    public String getDescription(String scope) {
+        return new XMLOutputter().outputString(getServiceDocument(scope));
+    }
+
+    @Override
+    public String getResultsString(Context context, String format, String query, int totalResults, int start,
+                                   int pageSize,
+                                   IndexableObject scope, List<IndexableObject> results,
+                                   Map<String, String> labels) throws IOException {
+        try {
+            return getResults(context, format, query, totalResults, start, pageSize, scope, results, labels)
+                .outputString();
+        } catch (FeedException e) {
+            log.error(e.toString(), e);
+            throw new IOException("Unable to generate feed", e);
+        }
+    }
+
+    @Override
+    public Document getResultsDoc(Context context, String format, String query, int totalResults, int start,
+                                  int pageSize,
+                                  IndexableObject scope, List<IndexableObject> results, Map<String, String> labels)
+        throws IOException {
+        try {
+            return getResults(context, format, query, totalResults, start, pageSize, scope, results, labels)
+                .outputW3CDom();
+        } catch (FeedException e) {
+            log.error(e.toString(), e);
+            throw new IOException("Unable to generate feed", e);
+        }
+    }
+
+    protected SyndicationFeed getResults(Context context, String format, String query, int totalResults, int start,
+                                         int pageSize, IndexableObject scope,
+                                         List<IndexableObject> results, Map<String, String> labels) {
+        // Encode results in requested format
+        if ("rss".equals(format)) {
+            format = "rss_2.0";
+        } else if ("atom".equals(format)) {
+            format = "atom_1.0";
+        }
+
+        SyndicationFeed feed = new SyndicationFeed(labels.get(SyndicationFeed.MSG_UITYPE));
+        feed.populate(null, context, scope, results, labels);
+        feed.setType(format);
+        feed.addModule(openSearchMarkup(query, totalResults, start, pageSize));
+        return feed;
+    }
+
+    /*
+     * Generates the OpenSearch elements which are added to the RSS or Atom feeds as foreign markup
+     * wrapped in a module
+     *
+     * @param query the search query
+     * @param qRes the search results
+     * @return module
+     */
+    protected OpenSearchModule openSearchMarkup(String query, int totalResults, int start, int pageSize) {
+        OpenSearchModule osMod = new OpenSearchModuleImpl();
+        osMod.setTotalResults(totalResults);
+        osMod.setStartIndex(start);
+        osMod.setItemsPerPage(pageSize);
+        OSQuery osq = new OSQuery();
+        osq.setRole("request");
+        try {
+            if (StringUtils.isNotBlank(query)) {
+                osq.setSearchTerms(URLEncoder.encode(query, "UTF-8"));
+            }
+        } catch (UnsupportedEncodingException e) {
+            log.error(e);
+        }
+        osq.setStartPage(1 + (start / pageSize));
+        osMod.addQuery(osq);
+        return osMod;
+    }
+
+    /**
+     * Returns as a document the OpenSearch service document
+     *
+     * @param scope - null for the entire repository, or a collection/community handle
+     * @return Service Document
+     */
+    protected org.jdom2.Document getServiceDocument(String scope) {
+        ConfigurationService config = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+        Namespace ns = Namespace.getNamespace(osNs);
+        Element root = new Element("OpenSearchDescription", ns);
+        root.addContent(new Element("ShortName", ns).setText(config.getProperty("websvc.opensearch.shortname")));
+        root.addContent(new Element("LongName", ns).setText(config.getProperty("websvc.opensearch.longname")));
+        root.addContent(new Element("Description", ns).setText(config.getProperty("websvc.opensearch.description")));
+        root.addContent(new Element("InputEncoding", ns).setText("UTF-8"));
+        root.addContent(new Element("OutputEncoding", ns).setText("UTF-8"));
+        // optional elements
+        String sample = config.getProperty("websvc.opensearch.samplequery");
+        if (sample != null && sample.length() > 0) {
+            Element sq = new Element("Query", ns).setAttribute("role", "example");
+            root.addContent(sq.setAttribute("searchTerms", sample));
+        }
+        String tags = config.getProperty("websvc.opensearch.tags");
+        if (tags != null && tags.length() > 0) {
+            root.addContent(new Element("Tags", ns).setText(tags));
+        }
+        String contact = config.getProperty("mail.admin");
+        if (contact != null && contact.length() > 0) {
+            root.addContent(new Element("Contact", ns).setText(contact));
+        }
+        String faviconUrl = config.getProperty("websvc.opensearch.faviconurl");
+        if (faviconUrl != null && faviconUrl.length() > 0) {
+            String dim = String.valueOf(16);
+            String type = faviconUrl.endsWith("ico") ? "image/vnd.microsoft.icon" : "image/png";
+            Element fav = new Element("Image", ns).setAttribute("height", dim).setAttribute("width", dim).
+                setAttribute("type", type).setText(faviconUrl);
+            root.addContent(fav);
+        }
+        // service URLs
+        for (String format : getFormats()) {
+            Element url = new Element("Url", ns).setAttribute("type", getContentType(format));
+            StringBuilder template = new StringBuilder();
+            if ("html".equals(format)) {
+                template.append(getBaseSearchUIURL());
+            } else {
+                template.append(getBaseSearchServiceURL());
+            }
+            template.append("?query={searchTerms}");
+            if (!"html".equals(format)) {
+                template.append("&start={startIndex?}&rpp={count?}&format=");
+                template.append(format);
+            }
+            if (scope != null) {
+                template.append("&scope=");
+                template.append(scope);
+            }
+            url.setAttribute("template", template.toString());
+            root.addContent(url);
+        }
+        return new org.jdom2.Document(root);
+    }
+
+    /**
+     * Converts a JDOM document to a W3C one
+     *
+     * @param jdomDoc jDOM document to convert
+     * @return W3C Document object
+     * @throws IOException if IO error
+     */
+    protected Document jDomToW3(org.jdom2.Document jdomDoc) throws IOException {
+        DOMOutputter domOut = new DOMOutputter();
+        try {
+            return domOut.output(jdomDoc);
+        } catch (JDOMException jde) {
+            throw new IOException("JDOM output exception", jde);
+        }
+    }
+
+    @Override
+    public DSpaceObject resolveScope(Context context, String scope) throws SQLException {
+        if (scope == null || "".equals(scope)) {
+            return null;
+        }
+
+        DSpaceObject dso = handleService.resolveToObject(context, scope);
+        if (dso == null || dso.getType() == Constants.ITEM) {
+            throw new IllegalArgumentException(
+                "Scope handle " + scope + " should point to a valid Community or Collection");
+        }
+        return dso;
+    }
+
+}


### PR DESCRIPTION
In DRUM, when running in production, we run both the front-end and
back-end at the same URL, using the Kubernetes Ingress and rewrite rules
to send requests to either Angular or the DSpace server, as appropriate.

For OpenSearch, when run in Kubernetes, we want to use the Angular URL,
instead of the DSpace server URL, in the OpenSearch output (while
retaining the ability to use separate servers in local development).

To enable this, customized the "getBaseSearchServiceURL()" method in
the "OpenSearchServiceImpl" class to look for a UMD custom
"opensearch.server.url" property (which enables us to customize the
server hostname in Kubernetes), which defaults to the stock
"dspace.server.url" property if an "opensearch.server.url" property
value is not present.

Added Markdown documentation on OAI-PMH and OpenSearch customizations
to DSpace 7.

https://umd-dit.atlassian.net/browse/LIBDRUM-763