### PR TITLE
LIBDRUM-769. Add special groups for impersonated users

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -266,6 +266,8 @@ drum.ldap.bind.auth =
 drum.ldap.bind.password =
 drum.ldap.connect.timeout = 1000
 drum.ldap.read.timeout = 5000
+# Expiration time, in milliseconds, for the in-memory LDAP cache.
+drum.ldap.cacheTimeout = 300000
 
 #####################
 # REST API SETTINGS #

--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/authenticate/impl/LdapServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/authenticate/impl/LdapServiceImpl.java
@@ -29,8 +29,6 @@ public class LdapServiceImpl implements LdapService {
     /** log4j category */
     private static Logger log = LogManager.getLogger(LdapServiceImpl.class);
 
-    private org.dspace.core.Context context = null;
-    private DirContext ctx = null;
     private String strUid = null;
     private SearchResult entry = null;
 
@@ -43,34 +41,30 @@ public class LdapServiceImpl implements LdapService {
         DSpaceServicesFactory.getInstance().getConfigurationService();
 
     /**
+     * The client for calls to the LDAP server. Made protected for use in
+     * tests
+     */
+    protected LdapClient client;
+
+    /**
      * Configures the LDAP connection, based on configuration and environment
      * variables.
      */
     public LdapServiceImpl(org.dspace.core.Context context) throws NamingException {
-        this.context = context;
+        this.client = createLdapClient(context);
+    }
 
-        String strUrl = configurationService.getProperty("drum.ldap.url");
-        String strBindAuth = configurationService.getProperty("drum.ldap.bind.auth");
-        String strBindPassword =  configurationService.getProperty("drum.ldap.bind.password");
-        String strConnectTimeout =  configurationService.getProperty("drum.ldap.connect.timeout");
-        String strReadTimeout =  configurationService.getProperty("drum.ldap.read.timeout");
-
-        // Setup the JNDI environment
-        Properties env = new Properties();
-
-        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-        env.put(Context.REFERRAL, "follow");
-
-        env.put(Context.PROVIDER_URL, strUrl);
-        env.put(Context.SECURITY_PROTOCOL, "ssl");
-        env.put(javax.naming.Context.SECURITY_PRINCIPAL, strBindAuth);
-        env.put(javax.naming.Context.SECURITY_CREDENTIALS, strBindPassword);
-        env.put("com.sun.jndi.ldap.connect.timeout", strConnectTimeout);
-        env.put("com.sun.jndi.ldap.read.timeout", strReadTimeout);
-
-        // Create the directory context
-        log.debug("Initailizing new LDAP context");
-        ctx = new InitialDirContext(env);
+    /**
+     * Returns the LdapClient for use in querying the LDAP server
+     *
+     * This class it provided to enable tests to override calls to the LDAP
+     * server.
+     *
+     * @return the LdapClient for use in querying the LDAP server
+     */
+    protected LdapClient createLdapClient(org.dspace.core.Context context)
+            throws NamingException {
+        return new LdapClient(context);
     }
 
     /**
@@ -82,57 +76,8 @@ public class LdapServiceImpl implements LdapService {
     @Override
     public Ldap queryLdap(String strUid) {
         try {
-            if (ctx == null) {
-                return null;
-            }
-
-            this.strUid = strUid;
-            String strFilter = "uid=" + strUid;
-
-            // Setup the search controls
-            SearchControls sc =  new SearchControls();
-            sc.setReturningAttributes(strRequestAttributes);
-            sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
-
-            // Search
-            NamingEnumeration<SearchResult> entries = ctx.search("", strFilter, sc);
-
-            // Make sure we got something
-            if (entries == null) {
-                log.warn(LogHelper.getHeader(context,
-                                              "null returned on ctx.search for " + strFilter,
-                                              ""));
-                return null;
-            }
-
-            // Check for a match
-            if (!entries.hasMore()) {
-                log.debug(LogHelper.getHeader(context,
-                                              "no matching entries for " + strFilter,
-                                              ""));
-                return null;
-            }
-
-
-            // Get entry
-            entry = (SearchResult)entries.next();
-            log.debug(LogHelper.getHeader(context,
-                                          "matching entry for " + strUid + ": " + entry.getName(),
-                                          ""));
-            Ldap ldap = new Ldap(strUid, entry);
-
-            // Check for another match
-            if (entries.hasMore()) {
-                entry = null;
-                log.warn(LogHelper.getHeader(context,
-                                              "multiple matching entries for " + strFilter,
-                                              ""));
-                return null;
-            }
-
-            log.debug(LogHelper.getHeader(context,
-                                          "ldap entry:\n" + entry,
-                                          ""));
+            Ldap ldap = null;
+            ldap = client.queryLdapService(strUid);
             return ldap;
         } catch (NamingException ne) {
             log.error("LDAP NamingException for '" + strUid + "'", ne);
@@ -145,13 +90,8 @@ public class LdapServiceImpl implements LdapService {
      */
     @Override
     public void close() {
-        if (ctx != null) {
-            try {
-                ctx.close();
-                ctx = null;
-            } catch (NamingException e) {
-                // Do nothing
-            }
+        if (client != null) {
+            client.close();
         }
     }
 
@@ -161,6 +101,121 @@ public class LdapServiceImpl implements LdapService {
             return "null";
         }
         return strUid + " (" + entry.getName() + ")";
+    }
+
+    /**
+     * Implementation that constructs an LDAP client and performs operations
+     * against a real LDAP server.
+     */
+    public static class LdapClient {
+        private SearchResult entry;
+        private org.dspace.core.Context context;
+        private DirContext ctx;
+
+        public LdapClient(org.dspace.core.Context context)
+                throws NamingException {
+            String strUrl = configurationService.getProperty("drum.ldap.url");
+            String strBindAuth = configurationService.getProperty("drum.ldap.bind.auth");
+            String strBindPassword =  configurationService.getProperty("drum.ldap.bind.password");
+            String strConnectTimeout =  configurationService.getProperty("drum.ldap.connect.timeout");
+            String strReadTimeout =  configurationService.getProperty("drum.ldap.read.timeout");
+
+            // Setup the JNDI environment
+            Properties env = new Properties();
+
+            env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+            env.put(Context.REFERRAL, "follow");
+
+            env.put(Context.PROVIDER_URL, strUrl);
+            env.put(Context.SECURITY_PROTOCOL, "ssl");
+            env.put(javax.naming.Context.SECURITY_PRINCIPAL, strBindAuth);
+            env.put(javax.naming.Context.SECURITY_CREDENTIALS, strBindPassword);
+            env.put("com.sun.jndi.ldap.connect.timeout", strConnectTimeout);
+            env.put("com.sun.jndi.ldap.read.timeout", strReadTimeout);
+
+
+            log.debug("Initializing new LDAP context");
+            this.ctx = new InitialDirContext(env);
+
+            this.context = context;
+        }
+
+        /**
+         * Returns an Ldap object returned by an LDAP server for the given user
+         * id, or null, of the user id is not found.
+         *
+         * @param strUid the user id to search for in the LDAP server.
+         * @return an Ldap object returned by an LDAP server for the given user
+         * id, or null, of the user id is not found.
+         */
+        public Ldap queryLdapService(String strUid) throws NamingException {
+            if (ctx == null) {
+                return null;
+            }
+
+            String strFilter = "uid=" + strUid;
+
+            // Setup the search controls
+            SearchControls sc =  new SearchControls();
+            sc.setReturningAttributes(strRequestAttributes);
+            sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+            // Search
+            log.debug("Searching LDAP server for {}", strUid);
+            NamingEnumeration<SearchResult> entries = ctx.search("", strFilter, sc);
+
+            // Make sure we got something
+            if (entries == null) {
+                log.warn(LogHelper.getHeader(context,
+                                                "null returned on ctx.search for " + strFilter,
+                                                ""));
+                return null;
+            }
+
+            // Check for a match
+            if (!entries.hasMore()) {
+                log.debug(LogHelper.getHeader(context,
+                                                "no matching entries for " + strFilter,
+                                                ""));
+                return null;
+            }
+
+
+            // Get entry
+            entry = (SearchResult)entries.next();
+            log.debug(LogHelper.getHeader(context,
+                                            "matching entry for " + strUid + ": " + entry.getName(),
+                                            ""));
+            Ldap ldap = new Ldap(strUid, entry);
+
+            // Check for another match
+            if (entries.hasMore()) {
+                entry = null;
+                log.warn(LogHelper.getHeader(context,
+                                                "multiple matching entries for " + strFilter,
+                                                ""));
+                return null;
+            }
+
+            log.debug(LogHelper.getHeader(context,
+                                            "ldap entry:\n" + entry,
+                                            ""));
+            return ldap;
+        }
+
+        /**
+         * Close the ldap connection
+         */
+        public void close() {
+            if (ctx != null) {
+                try {
+                    ctx.close();
+                    ctx = null;
+                } catch (NamingException e) {
+                    // Do nothing
+                }
+            }
+        }
     }
 }
 

--- a/dspace/modules/additions/src/test/java/org/dspace/authenticate/CASAuthenticationTest.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/authenticate/CASAuthenticationTest.java
@@ -65,17 +65,21 @@ public class CASAuthenticationTest extends AbstractUnitTest {
     @Test
     public void authenticate_fails_LdapUserNotFound() throws Exception {
         HttpServletRequest mockRequest = new MockHttpServletRequest("", Map.of("ticket", "ST-CAS-TICKET"));
+        LdapService mockLdapService = MockLdapService.userNotFound();
 
         CASAuthentication stubCas = new CASAuthentication() {
             @Override
             protected String getNetIdFromCasTicket(Context context, String ticket, String serviceUrl) {
                 return "no_such_user";
             }
+
+            @Override
+            protected LdapService createLdapService(Context context) {
+                return mockLdapService;
+            }
         };
 
-        LdapService mockLdapService = MockLdapService.userNotFound();
-
-        int response = stubCas.authenticate(context, null, null, null, mockRequest, mockLdapService);
+        int response = stubCas.authenticate(context, null, null, null, mockRequest);
 
         assertEquals("Expected AuthenticationMethod.NO_SUCH_USER",
                 AuthenticationMethod.NO_SUCH_USER, response);
@@ -89,6 +93,7 @@ public class CASAuthenticationTest extends AbstractUnitTest {
         int initialEPersonCount = ePersonService.countTotal(context);
 
         HttpServletRequest mockRequest = new MockHttpServletRequest("", Map.of("ticket", "ST-CAS-TICKET"));
+        LdapService mockLdapService = MockLdapService.userFound();
 
         CASAuthentication stubCas = new CASAuthentication() {
             @Override
@@ -101,11 +106,14 @@ public class CASAuthenticationTest extends AbstractUnitTest {
                     throws SQLException {
                 return false;
             }
+
+            @Override
+            protected LdapService createLdapService(Context context) {
+                return mockLdapService;
+            }
         };
 
-        LdapService mockLdapService = MockLdapService.userFound();
-
-        int response = stubCas.authenticate(context, null, null, null, mockRequest, mockLdapService);
+        int response = stubCas.authenticate(context, null, null, null, mockRequest);
 
         assertEquals("Expected AuthenticationMethod.NO_SUCH_USER",
                 AuthenticationMethod.NO_SUCH_USER, response);
@@ -125,17 +133,21 @@ public class CASAuthenticationTest extends AbstractUnitTest {
         ePersonService.update(context, eperson);
 
         HttpServletRequest mockRequest = new MockHttpServletRequest("", Map.of("ticket", "ST-CAS-TICKET"));
+        LdapService mockLdapService = MockLdapService.userFound();
 
         CASAuthentication stubCas = new CASAuthentication() {
             @Override
             protected String getNetIdFromCasTicket(Context context, String ticket, String serviceUrl) {
                 return netid;
             }
+
+            @Override
+            protected LdapService createLdapService(Context context) {
+                return mockLdapService;
+            }
         };
 
-        LdapService mockLdapService = MockLdapService.userFound();
-
-        int response = stubCas.authenticate(context, null, null, null, mockRequest, mockLdapService);
+        int response = stubCas.authenticate(context, null, null, null, mockRequest);
 
         assertEquals("Expected AuthenticationMethod.CERT_REQUIRED",
                 AuthenticationMethod.CERT_REQUIRED, response);
@@ -150,17 +162,21 @@ public class CASAuthenticationTest extends AbstractUnitTest {
         ePersonService.update(context, eperson);
 
         HttpServletRequest mockRequest = new MockHttpServletRequest("", Map.of("ticket", "ST-CAS-TICKET"));
+        LdapService mockLdapService = MockLdapService.userFound();
 
         CASAuthentication stubCas = new CASAuthentication() {
             @Override
             protected String getNetIdFromCasTicket(Context context, String ticket, String serviceUrl) {
                 return netid;
             }
+
+            @Override
+            protected LdapService createLdapService(Context context) {
+                return mockLdapService;
+            }
         };
 
-        LdapService mockLdapService = MockLdapService.userFound();
-
-        int response = stubCas.authenticate(context, null, null, null, mockRequest, mockLdapService);
+        int response = stubCas.authenticate(context, null, null, null, mockRequest);
 
         assertEquals("Expected AuthenticationMethod.BAD_ARGS",
                 AuthenticationMethod.BAD_ARGS, response);
@@ -175,17 +191,21 @@ public class CASAuthenticationTest extends AbstractUnitTest {
         ePersonService.update(context, eperson);
 
         HttpServletRequest mockRequest = new MockHttpServletRequest("", Map.of("ticket", "ST-CAS-TICKET"));
+        LdapService mockLdapService = MockLdapService.userFound();
 
         CASAuthentication stubCas = new CASAuthentication() {
             @Override
             protected String getNetIdFromCasTicket(Context context, String ticket, String serviceUrl) {
                 return netid;
             }
+
+            @Override
+            protected LdapService createLdapService(Context context) {
+                return mockLdapService;
+            }
         };
 
-        LdapService mockLdapService = MockLdapService.userFound();
-
-        int response = stubCas.authenticate(context, null, null, null, mockRequest, mockLdapService);
+        int response = stubCas.authenticate(context, null, null, null, mockRequest);
 
         assertEquals("Expected AuthenticationMethod.SUCCESS",
                 AuthenticationMethod.SUCCESS, response);
@@ -196,6 +216,15 @@ public class CASAuthenticationTest extends AbstractUnitTest {
         String netid = "eperson_that_does_not_exist_yet";
 
         HttpServletRequest mockRequest = new MockHttpServletRequest("", Map.of("ticket", "ST-CAS-TICKET"));
+
+        // Set up MockLdapService so we can verify that the "registerEPerson"
+        // method was called.
+        MockLdapService mockLdapService = new MockLdapService() {
+            @Override
+            public Ldap queryLdap(String strUid) {
+                return new Ldap(strUid, null);
+            }
+        };
 
         MockCASAuthentication stubCas = new MockCASAuthentication() {
             @Override
@@ -208,18 +237,14 @@ public class CASAuthenticationTest extends AbstractUnitTest {
                     throws SQLException {
                 return true;
             }
-        };
 
-        // Set up MockLdapService so we can verify that the "registerEPerson"
-        // method was called.
-        MockLdapService mockLdapService = new MockLdapService() {
             @Override
-            public Ldap queryLdap(String strUid) {
-                return new Ldap(strUid, null);
+            protected LdapService createLdapService(Context context) {
+                return mockLdapService;
             }
         };
 
-        int response = stubCas.authenticate(context, null, null, null, mockRequest, mockLdapService);
+        int response = stubCas.authenticate(context, null, null, null, mockRequest);
 
         assertEquals("Expected AuthenticationMethod.SUCCESS",
                 AuthenticationMethod.SUCCESS, response);

--- a/dspace/modules/additions/src/test/java/org/dspace/authenticate/impl/LdapServiceImplTest.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/authenticate/impl/LdapServiceImplTest.java
@@ -59,33 +59,33 @@ public class LdapServiceImplTest extends AbstractUnitTest {
         // otherwise will be persistent (as a Mockito spy) across tests
         ldapService.resetLdapQueryCache();
     }
+}
 
-    /**
-     * Testable implementation of the LdapServiceImpl class that replaces
-     * the LdapServerDelegate with a mock implementation, and allows the
-     * ldapQueryCache to be accessed.
-     */
-    class TestableLdapServiceImpl extends LdapServiceImpl {
-        public TestableLdapServiceImpl(org.dspace.core.Context context) throws NamingException {
-            super(context);
-        }
+/**
+ * Testable implementation of the LdapServiceImpl class that replaces
+ * the LdapServerDelegate with a mock implementation, and allows the
+ * ldapQueryCache to be accessed.
+ */
+class TestableLdapServiceImpl extends LdapServiceImpl {
+    public TestableLdapServiceImpl(org.dspace.core.Context context) throws NamingException {
+        super(context);
+    }
 
-        @Override
-        protected LdapClient createLdapClient(org.dspace.core.Context context) throws NamingException {
-            return mock(LdapServiceImpl.LdapClient.class);
-        }
+    @Override
+    protected LdapClient createLdapClient(org.dspace.core.Context context) throws NamingException {
+        return mock(LdapServiceImpl.LdapClient.class);
+    }
 
-        public LdapClient getClient() {
-            return this.client;
-        }
+    public LdapClient getClient() {
+        return this.client;
+    }
 
-        public Map<String, Ldap> replaceCacheWithSpy() {
-            ldapQueryCache = spy(LdapServiceImpl.ldapQueryCache);
-            return ldapQueryCache;
-        }
+    public Map<String, Ldap> replaceCacheWithSpy() {
+        ldapQueryCache = spy(LdapServiceImpl.ldapQueryCache);
+        return ldapQueryCache;
+    }
 
-        public void resetLdapQueryCache() {
-            ldapQueryCache = null;
-        }
+    public void resetLdapQueryCache() {
+        ldapQueryCache = null;
     }
 }

--- a/dspace/modules/additions/src/test/java/org/dspace/authenticate/impl/LdapServiceImplTest.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/authenticate/impl/LdapServiceImplTest.java
@@ -1,0 +1,91 @@
+package org.dspace.authenticate.impl;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import javax.naming.NamingException;
+
+import edu.umd.lib.dspace.authenticate.impl.Ldap;
+import edu.umd.lib.dspace.authenticate.impl.LdapServiceImpl;
+import edu.umd.lib.dspace.authenticate.impl.LdapServiceImpl.LdapClient;
+import org.dspace.AbstractUnitTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LdapServiceImplTest extends AbstractUnitTest {
+    private TestableLdapServiceImpl ldapService;
+    private LdapClient client;
+    private Map<String, Ldap> ldapQueryCache;
+
+    @Before
+    public void setUp() throws Exception {
+        this.ldapService = new TestableLdapServiceImpl(context);
+        this.client = ldapService.getClient();
+        this.ldapQueryCache = ldapService.replaceCacheWithSpy();
+        when(client.queryLdapService(any())).thenReturn(new Ldap("testUser", null));
+    }
+
+    @Test
+    public void ldapCacheMissesOnFirstUse() throws Exception {
+        Ldap ldap = ldapService.queryLdap("testUser");
+
+        assertNotNull(ldap);
+        verify(ldapQueryCache, times(1)).containsKey(any());
+        verify(client, times(1)).queryLdapService(any());
+    }
+
+    @Test
+    public void ldapCacheUsedOnSecondCall() throws Exception {
+        Ldap ldap1 = ldapService.queryLdap("testUser");
+        Ldap ldap2 = ldapService.queryLdap("testUser");
+
+        assertNotNull(ldap1);
+        assertNotNull(ldap2);
+        verify(ldapQueryCache, times(2)).containsKey(any());
+        verify(ldapQueryCache, times(1)).get(any());
+        verify(client, times(1)).queryLdapService(any());
+    }
+
+    @After
+    public void tearDown() {
+        // Reset the ldapQueryCache because it is a static variable that
+        // otherwise will be persistent (as a Mockito spy) across tests
+        ldapService.resetLdapQueryCache();
+    }
+
+    /**
+     * Testable implementation of the LdapServiceImpl class that replaces
+     * the LdapServerDelegate with a mock implementation, and allows the
+     * ldapQueryCache to be accessed.
+     */
+    class TestableLdapServiceImpl extends LdapServiceImpl {
+        public TestableLdapServiceImpl(org.dspace.core.Context context) throws NamingException {
+            super(context);
+        }
+
+        @Override
+        protected LdapClient createLdapClient(org.dspace.core.Context context) throws NamingException {
+            return mock(LdapServiceImpl.LdapClient.class);
+        }
+
+        public LdapClient getClient() {
+            return this.client;
+        }
+
+        public Map<String, Ldap> replaceCacheWithSpy() {
+            ldapQueryCache = spy(LdapServiceImpl.ldapQueryCache);
+            return ldapQueryCache;
+        }
+
+        public void resetLdapQueryCache() {
+            ldapQueryCache = null;
+        }
+    }
+}


### PR DESCRIPTION
Modified "getSpecialGroups" method in "CASAuthentication" to support
populating special groups for impersonated users.

Since the "getSpecialGroups" method is called for every HTTP request,
which for impersonated users may require an LDAP search, modified
the LdapServiceImpl class to cache LDAP results for 5 minutes, to
limit the number of actual calls to the server.

Refactored the code to enable testing.

Added a "drum.ldap.cacheTimeout" parameter to "local.cfg.EXAMPLE"
to control the LdapServiceImpl cache timeout.

https://umd-dit.atlassian.net/browse/LIBDRUM-769