### PR TITLE
LIBDRUM-802. Pin Postgres version to 12.14

### DIFF
--- a/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # This will be deployed as dspace/dspace-postgres-pgcrpyto:latest
-FROM postgres:12
+FROM postgres:12.14
 
 ENV POSTGRES_DB dspace
 ENV POSTGRES_USER dspace


### PR DESCRIPTION
The latest Postgres 12 version, Postgres 12.15, appears to have some sort of issue with populating the database from downloaded sample data at startup.

Instead of processing the Postgres dump, the following is in the log:

```
server started
CREATE DATABASE

/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/mdsoar.sql
SET
SET
SET
SET
SET
 set_config
------------

(1 row)
```

The existing steps work correctly with Postgres 12.14, so pinning to that version until a deeper investigation can be performed (or the problem simply corrects itself in the next version).

https://umd-dit.atlassian.net/browse/LIBDRUM-802

