### PR TITLE
LIBDRUM-808. Replace Google Analytics config with Matomo config

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -312,9 +312,11 @@ crosswalk.dissemination.DataCite.publisher = Digital Repository at the Universit
 crosswalk.dissemination.DataCite.stylesheet = crosswalks/DIM2UmdDataCite.xsl
 
 ####################
-# GOOGLE ANALYTICS #
+# MATOMO ANALYTICS #
 ####################
-xmlui.google.analytics.key=
+matomo.analytics.url =
+matomo.analytics.site-id =
+matomo.analytics.cdn-src =
 
 #####################
 # LOGLEVEL SETTINGS #

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -52,6 +52,11 @@ rest.properties.exposed = google.recaptcha.mode
 # JSON-LD Website. See dspace/config/modules/rest.cfg
 rest.properties.exposed = dspace.name
 rest.properties.exposed = dspace.baseUrl
+
+# Matomo Analytics web tracker properties
+rest.properties.exposed = matomo.analytics.url
+rest.properties.exposed = matomo.analytics.site-id
+rest.properties.exposed = matomo.analytics.cdn-src
 # End UMD Customization
 
 #---------------------------------------------------------------#


### PR DESCRIPTION
Updated "dspace/config/local.cfg.EXAMPLE" with the configuration properties for Matomo Analytics, replacing the Google Analytics properties, which are no longer needed.

Modified the "dspace/config/modules/rest.cfg" configuration to make the Matomo analytics properties accessible to the Angular front-end.

https://umd-dit.atlassian.net/browse/LIBDRUM-808
