### PR TITLE
LIBDRUM-811. Increase the maximum allowed upload file size

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -293,11 +293,13 @@ drum.ldap.cacheTimeout = 300000
 # These defaults are specified in [dspace-src]/dspace-server-webapp/src/main/resources/application.properties
 # but may be overridden in this local.cfg
 #
+#  UMD Customization
 # Maximum size of a single uploaded file
-#spring.servlet.multipart.max-file-size = 512MB
+spring.servlet.multipart.max-file-size = 2048MB
 
 # Maximum size of a multipart request (i.e. max total size of all files in one request)
-#spring.servlet.multipart.max-request-size = 512MB
+spring.servlet.multipart.max-request-size = 15360MB
+# End UMD Customization
 
 #####################
 # DOI CONFIGURATION #

--- a/dspace/docs/DrumFeatures.md
+++ b/dspace/docs/DrumFeatures.md
@@ -151,3 +151,5 @@ See [dspace/docs/DrumCronTasks.md](DrumCronTasks.md) for additional information.
   to Faculty collections. (see also LIBDRUM-676)
 * LIBDRUM-666 - "Preservation" bundle type option provided for bitstreams
   bundles
+* LIBDRUM-811 - Maximum file upload size is set to 2GB for a single file
+  and 15GB for a record with multiple files.


### PR DESCRIPTION
Modified the "local.cfg.EXAMPLE" file to increase the maximum upload file size, based on guidance from Terry Owen:

```
... upper limit for a single file is 2GB and 15GB for a record with
multiple files.
```

https://umd-dit.atlassian.net/browse/LIBDRUM-811
