### PR TITLE
LIBDRUM-844. Disable "By Subject Category" Browse option

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -367,6 +367,9 @@ webui.browse.index.3 = title:item:title
 webui.browse.index.4 = subject:metadata:dc.subject.*:text
 #webui.browse.index.5 = dateaccessioned:item:dateaccessioned
 
+# Disable "Browse by Subject Category
+webui.browse.vocabularies.disabled = srsc
+
 # OpenSearch settings
 websvc.opensearch.enable = true
 websvc.opensearch.shortname = drum

--- a/dspace/docs/DrumFeatures.md
+++ b/dspace/docs/DrumFeatures.md
@@ -139,6 +139,7 @@ information.
 * LIBDRUM-739 - "Has Files" removed from search options
 * LIBDRUM-746 - "Abstract" field modified to not preserve line breaks when
   displayed
+* LIBDRUM-844 - Disable "By Subject Category" Browse option
 
 ## DRUM DOI
 


### PR DESCRIPTION
The "By Subject Category" browse category was returning inconsistent results so it was disabled using the configuration property indicated in https://wiki.lyrasis.org/display/DSDOC7x/Configuration+Reference#ConfigurationReference-HierarchicalBrowseIndexes

The other browse options -- "By Issue Date", "By Author", "By Title", and "By Subject" remain in place.

https://umd-dit.atlassian.net/browse/LIBDRUM-844
