### PR TITLE
LIBITD-2487. Fix Jenkinsfile for Jenkins v2.440.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,8 @@ pipeline {
             // Filter out the hundreds of TODOs warnings at the "INFO" level
             // from the stock DSpace code
             filters: [excludeType('TodoCommentCheck')],
-            unstableTotalNormal: 1, enabledForFailure: true)
+            qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']],
+            enabledForFailure: true)
         }
       }
     }


### PR DESCRIPTION
Updated the "recordIssues" directive in the "Jenkinsfile" to use the "qualityGates" parameter, instead of the obsolete "unstableTotalAll" parameter.

https://umd-dit.atlassian.net/browse/LIBITD-2487