### PR TITLE
LIBDRUM-859. Fix OpenSearch NullPointerException for unknown valid UUIDs

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ScopeResolver.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ScopeResolver.java
@@ -35,6 +35,24 @@ public class ScopeResolver {
     @Autowired
     CommunityService communityService;
 
+    // UMD Customization
+    // This change has been provided to DSpace in Pull Request 9482
+    // https://github.com/DSpace/DSpace/pull/9482
+    // This customization marker can be remove when MD-SOAR is update to
+    // a DSpace version containing this change.
+    /**
+     * Returns an IndexableObject corresponding to the community or collection
+     * of the given scope, or null if the scope is not a valid UUID, or is a
+     * valid UUID that does not correspond to a community of collection.
+     *
+     * @param context the DSpace context
+     * @param scope a String containing the UUID of the community or collection
+     * to return.
+     * @return an IndexableObject corresponding to the community or collection
+     * of the given scope, or null if the scope is not a valid UUID, or is a
+     * valid UUID that does not correspond to a community of collection.
+     */
+    // End UMD Customization
     public IndexableObject resolveScope(Context context, String scope) {
         IndexableObject scopeObj = null;
         if (StringUtils.isNotBlank(scope)) {
@@ -43,6 +61,22 @@ public class ScopeResolver {
                 scopeObj = new IndexableCommunity(communityService.find(context, uuid));
                 if (scopeObj.getIndexedObject() == null) {
                     scopeObj = new IndexableCollection(collectionService.find(context, uuid));
+                    // UMD Customization
+                    // This change has been provided to DSpace in Pull Request 9482
+                    // https://github.com/DSpace/DSpace/pull/9482
+                    // This customization marker can be remove when MD-SOAR is update to
+                    // a DSpace version containing this change.
+                    if (scopeObj.getIndexedObject() == null) {
+                        // Can't find the UUID as a community or collection
+                        // so log and return null
+                        log.warn(
+                            "The given scope string " +
+                            StringUtils.trimToEmpty(scope) +
+                            " is not a collection or community UUID."
+                        );
+                        scopeObj = null;
+                    }
+                    // End UMD Customization
                 }
             } catch (IllegalArgumentException ex) {
                 log.warn("The given scope string " + StringUtils.trimToEmpty(scope) + " is not a UUID", ex);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
@@ -269,4 +269,38 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
                    .andExpect(status().isOk())
                    .andExpect(xpath("rss/channel/description").string("No Description"));
     }
+
+    // UMD Customization
+    // This change has been provided to DSpace in Pull Request 9482
+    // https://github.com/DSpace/DSpace/pull/9482
+    // This customization marker can be remove when MD-SOAR is update to
+    // a DSpace version containing this change.
+    @Test
+    public void scopeNotCommunityOrCollectionUUIDTest() throws Exception {
+        // Tests that a OpenSearch response with 1 result (equivalent to an
+        // unscoped request) is returned if the "scope" UUID is a
+        // validly-formatted UUID, but not a community or collection UUID.
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection collection1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                                           .build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, collection1)
+                                           .withTitle("Boars at Yellowstone")
+                                           .withIssueDate("2017-10-17")
+                                           .withAuthor("Ballini, Andreas").withAuthor("Moriarti, Susan")
+                                           .build();
+
+        // UUID is valid, but not a community or collection UUID
+        String testUUID = "b68f0d1c-7316-41dc-835d-46b79b35642e";
+
+        getClient().perform(get("/opensearch/search")
+                   .param("scope", testUUID)
+                   .param("query", "*"))
+                   .andExpect(status().isOk())
+                   .andExpect(xpath("feed/totalResults").string("1"));
+    }
+    // End UMD Customization
 }


### PR DESCRIPTION
Fixes a NullPointerException when the "scope" parameter provided to the OpenSearch endpoint is a valid UUID, but is not a UUID associated with a Community or Collection.

Instead of throwing a NullPointerException, this change modifies the code to return a null scope (resulting in an "unscoped" OpenSearch request), as if the UUID were invalid, or otherwise not usable.

This fix was provided to DSpace as Pull Request #9482 - <DSpace/DSpace#9482>. The customization markers
added in this issue can be removed when DRUM is updated to a DSpace version containing this change.

https://umd-dit.atlassian.net/browse/LIBDRUM-859
