### PR TITLE
LIBDRUM-866. Updated DIM2UmdDataCite.xsl for DataCite Schema 4.5

### DIFF
--- a/dspace/config/crosswalks/DIM2UmdDataCite.xsl
+++ b/dspace/config/crosswalks/DIM2UmdDataCite.xsl
@@ -3,25 +3,29 @@
 <!--
     Document   : DIM2DataCite.xsl
     Created on : January 23, 2013, 1:26 PM
-    Updated on : November 26, 2015, 3:00 PM
-    Author     : pbecker, ffuerste
-    Description: Converts metadata from DSpace Intermediat Format (DIM) into
-                 metadata following the DataCite Schema for the Publication and
-                 Citation of Research Data, Version 3.1
+    Updated on : Jaunary 30, 2024, 3:00 PM
+    Author     : pbecker, ffuerste, ypaulsen
+    Description: Converts metadata from DSpace Intermediate Format (DIM) into
+                 metadata following the DataCite Metadata Schema 4.5
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
-                xmlns="http://datacite.org/schema/kernel-3"
+                xmlns="http://datacite.org/schema/kernel-4"
                 version="2.0">
-    
+
     <!-- CONFIGURATION -->
     <!-- The parameters prefix, publisher, datamanager and hostinginstitution
          moved to DSpace's configuration. They will be substituted automatically.
-         It is not necessary anymore to change this file.
          Please take a look into the DSpace documentation for details on how to
          change those. -->
-    <!-- DO NOT CHANGE ANYTHING BELOW THIS LINE EXCEPT YOU REALLY KNOW WHAT YOU ARE DOING! -->
-    
+    <!-- This file handles the transformation of metadata into the DataCite
+         Schema. You should customize it to match your local metadata schema
+         and submission forms. Please note that this must produce valid XML
+         according to the DataCite Schema. Otherwise you will not be able
+         to register DOIs anymore. Please follow and reuse the examples
+         included in this file. For more information on the DataCite
+         Schema, see https://schema.datacite.org. -->
+
     <!-- We need the prefix to determine DOIs that were minted by ourself. -->
     <xsl:param name="prefix">10.5072/dspace-</xsl:param>
     <!-- The content of the following parameter will be used as element publisher. -->
@@ -46,30 +50,30 @@
             properties are in the metadata of the item to export.
             The classe named above respects this.
         -->
-        <resource xmlns="http://datacite.org/schema/kernel-3"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd">
+        <resource xmlns="http://datacite.org/schema/kernel-4"
+                xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-            <!-- 
+            <!--
                 MANDATORY PROPERTIES
             -->
 
-            <!-- 
+            <!--
                 DataCite (1)
                 Template Call for DOI identifier.
                 Occ: 1
-            --> 
+            -->
             <!--
                 dc.identifier.uri may contain more than one DOI, e.g. if the
-                repository contains an item that is published by a publishing 
+                repository contains an item that is published by a publishing
                 company as well. We have to ensure to use URIs of our prefix
                 as primary identifiers only.
             -->
-            <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and starts-with(., concat('http://dx.doi.org/', $prefix))]" />
+            <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and (contains(., $prefix))]" />
 
-            <!-- 
+            <!--
                 DataCite (2)
-                Add creator information. 
+                Add creator information.
                 Occ: 1-n
             -->
             <creators>
@@ -85,7 +89,7 @@
                 </xsl:choose>
             </creators>
 
-            <!-- 
+            <!--
                 DataCite (3)
                 Add Title information.
                 Occ: 1-n
@@ -100,8 +104,8 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </titles>
-            
-            <!-- 
+
+            <!--
                 DataCite (4)
                 Add Publisher information from configuration above
                 Occ: 1
@@ -118,7 +122,7 @@
                 </xsl:choose>
             </xsl:element>
 
-            <!-- 
+            <!--
                 DataCite (5)
                 Add PublicationYear information
                 Occ: 1
@@ -139,7 +143,7 @@
                 </xsl:choose>
             </publicationYear>
 
-            <!-- 
+            <!--
                 OPTIONAL PROPERTIES
             -->
 
@@ -149,14 +153,14 @@
                 Occ: 0-n
                 Format: open
                 Attribute: subjectSchema (optional), schemeURI (optional)
-            -->  
+            -->
             <xsl:if test="//dspace:field[@mdschema='dc' and @element='subject']">
                 <subjects>
                     <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='subject']" />
                 </subjects>
             </xsl:if>
 
-            <!--
+            <!-- UMD Customization
                 DataCite (7)
                 Add contributorType from configuration above.
                 Template Call for Contributors
@@ -178,35 +182,35 @@
                 </xsl:element>
                 <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'][not(@qualifier='author')]" />
             </contributors>
-            --> 
+            End UMD Customization -->
 
-            <!--
+            <!-- UMD Customization
                 DataCite (8)
                 Template Call for Dates
                 Occ: 0-n
                 Required Attribute: dataType - controlled list
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='date' and 
-                        (@qualifier='accessioned' 
-                         or @qualifier='available' 
-                         or @qualifier='copyright' 
-                         or @qualifier='created' 
-                         or @qualifier='issued' 
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='date' and
+                        (@qualifier='accessioned'
+                         or @qualifier='available'
+                         or @qualifier='copyright'
+                         or @qualifier='created'
+                         or @qualifier='issued'
                          or @qualifier='submitted'
                          or @qualifier='updated')]" >
                 <xsl:element name="dates">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='date' and 
-                        (@qualifier='accessioned' 
-                         or @qualifier='available' 
-                         or @qualifier='copyright' 
-                         or @qualifier='created' 
-                         or @qualifier='issued' 
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='date' and
+                        (@qualifier='accessioned'
+                         or @qualifier='available'
+                         or @qualifier='copyright'
+                         or @qualifier='created'
+                         or @qualifier='issued'
                          or @qualifier='submitted'
                          or @qualifier='updated')]" />
                 </xsl:element>
             </xsl:if>
-            --> 
+            End UMD Customization -->
 
-            <!-- 
+            <!--
                 DataCite (9)
                 Templacte Call for Language
                 Occ: 0-1
@@ -219,9 +223,20 @@
                 Template call for ResourceType
                 DataCite allows the ResourceType to ouccre not more than once.
             -->
-            <xsl:apply-templates select="(//dspace:field[@mdschema='dc' and @element='type'])[1]" />
+            <!--<xsl:apply-templates select="(//dspace:field[@mdschema='dc' and @element='type'])[1]" />-->
+            <xsl:choose>
+                <xsl:when test="(//dspace:field[@mdschema='dc' and @element='type'])[1]">
+                    <xsl:apply-templates select="(//dspace:field[@mdschema='dc' and @element='type'])[1]" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:element name="resourceType">
+                        <xsl:attribute name="resourceTypeGeneral">Other</xsl:attribute>
+                        <xsl:value-of>Other</xsl:value-of>
+                    </xsl:element>
+                </xsl:otherwise>
+            </xsl:choose>
 
-            <!-- 
+            <!-- UMD Customization
                 DataCite (11)
                 Add alternativeIdentifiers.
                 This element is important as it is used to recognize for which
@@ -229,33 +244,49 @@
                 See the primary identifier for which the doi is registered.
                 Occ: 0-n
                 Required Attribute: alternateIdentifierType (free format)
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]">
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(contains(., $prefix))]">
                 <xsl:element name="alternateIdentifiers">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]" />
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(contains(., $prefix))]" />
                 </xsl:element>
             </xsl:if>
-            -->
+            End UMD Customization -->
 
             <!--
                 DataCite (12)
-                Add sizes.
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']">             
-                <xsl:element name="sizes">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']" />      
-                </xsl:element>
-            </xsl:if>
+                Add relatedIdentifier.
+                DataCite requires a relatedIdentifierType, but we do not know which
+                type of identifier is part of the dc.relation.* fields within DSpace.
+                Skip the related identifier until we find a proper solution.
             -->
 
-            <!-- DataCite (13)
+            <!-- UMD Customization
+                DataCite (13)
+                Add sizes.
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']">
+                <xsl:element name="sizes">
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']" />
+                </xsl:element>
+            </xsl:if>
+            End UMD Customization -->
+
+            <!-- UMD Customization 
+                 DataCite (14)
                  Add formats.
             <xsl:if test="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]">
                 <xsl:element name="formats">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]" />       
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]" />
                 </xsl:element>
             </xsl:if>
-            -->
+            End UMD Customization -->
 
             <!--
+                 DataCite (15)
+                 Add version.
+                 As we currently do not link versions as related identifier, we skip
+                the version information too.
+            -->
+
+            <!-- UMD Customization
                 DataCite (16)
                 Rights.
                 Occ: 0-1
@@ -264,7 +295,7 @@
                     <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='rights']" />
                 </xsl:element>
             </xsl:if>
-            -->
+            End UMD Customization -->
 
             <!--
                 DataCite (17)
@@ -272,33 +303,47 @@
                 Occ: 0-n
                 Required Attribute: descriptionType - controlled list
             -->
+            <!-- UMD Customization -->
             <xsl:if test="//dspace:field[@mdschema='dc' and @element='description'][not(@qualifier='provenance')]">
                 <xsl:element name="descriptions">
                     <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='description' and (@qualifier='abstract' or not(@qualifier))]" />
                 </xsl:element>
             </xsl:if>
-            
+            <!-- End UMD Customization -->
+
             <!--
                 DataCite (18)
                 GeoLocation
                 DSpace currently doesn't store geolocations.
             -->
-
+            <!--
+                DataCite (19)
+                FundingReference
+                DSpace currently doesn't store FundingReference.
+            -->
+            <!--
+                DataCite (20)
+                RelatedItem
+            -->
         </resource>
     </xsl:template>
 
-    <!-- TEMPLATES -->
 
     <!-- Add doi identifier information. -->
     <!--
         dc.identifier.uri may contain more than one DOI, e.g. if the
-        repository contains an item that is published by a publishing 
+        repository contains an item that is published by a publishing
         company as well. We have to ensure to use URIs of our prefix
         as primary identifiers only.
     -->
-    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and starts-with(., concat('http://dx.doi.org/', $prefix))]">
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and (contains(., $prefix))]">
         <identifier identifierType="DOI">
-            <xsl:value-of select="substring(., 19)"/>
+            <xsl:if test="starts-with(string(text()), 'https://doi.org/')">
+                <xsl:value-of select="substring(., 17)"/>
+            </xsl:if>
+            <xsl:if test="starts-with(string(text()), 'http://dx.doi.org/')">
+                <xsl:value-of select="substring(., 19)"/>
+            </xsl:if>
         </identifier>
     </xsl:template>
 
@@ -314,34 +359,39 @@
     <!-- DataCite (3) :: Title -->
     <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
         <xsl:element name="title">
+            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
             <xsl:if test="@qualifier='alternative'">
+                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
                 <xsl:attribute name="titleType">AlternativeTitle</xsl:attribute>
             </xsl:if>
-            <!-- DSpace does include niehter a dc.title.subtitle nor a 
-                 dc.title.translated. If necessary, please create those in the 
+            <!-- DSpace does include niehter a dc.title.subtitle nor a
+                 dc.title.translated. If necessary, please create those in the
                  metadata field registry. -->
             <xsl:if test="@qualifier='subtitle'">
+                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
                 <xsl:attribute name="titleType">Subtitle</xsl:attribute>
             </xsl:if>
             <xsl:if test="@qualifier='translated'">
+                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
                 <xsl:attribute name="titleType">TranslatedTitle</xsl:attribute>
             </xsl:if>
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
 
-    <!-- 
+    <!--
         DataCite (6), DataCite (6.1)
         Adds subject and subjectScheme information
-    
-        "This term is intended to be used with non-literal values as defined in the 
-        DCMI Abstract Model (http://dublincore.org/documents/abstract-model/). 
-        As of December 2007, the DCMI Usage Board is seeking a way to express 
-        this intention with a formal range declaration." 
+
+        "This term is intended to be used with non-literal values as defined in the
+        DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).
+        As of December 2007, the DCMI Usage Board is seeking a way to express
+        this intention with a formal range declaration."
         (http://dublincore.org/documents/dcmi-terms/#terms-subject)
     -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='subject']">
         <xsl:element name="subject">
+            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
             <xsl:if test="@qualifier">
                 <xsl:attribute name="subjectScheme"><xsl:value-of select="@qualifier" /></xsl:attribute>
             </xsl:if>
@@ -349,12 +399,12 @@
         </xsl:element>
     </xsl:template>
 
-    <!--
+    <!-- UMD Customization
         DataCite (7), DataCite (7.1)
         Adds contributor and contributorType information
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor'][not(@qualifier='author')]">
         <xsl:choose>
-            <xsl:when test="@qualifier='editor'"> 
+            <xsl:when test="@qualifier='editor'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Editor</xsl:attribute>
                     <contributorName>
@@ -362,7 +412,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="@qualifier='advisor'"> 
+            <xsl:when test="@qualifier='advisor'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">RelatedPerson</xsl:attribute>
                     <contributorName>
@@ -370,7 +420,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="@qualifier='illustrator'"> 
+            <xsl:when test="@qualifier='illustrator'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
@@ -378,7 +428,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="@qualifier='other'"> 
+            <xsl:when test="@qualifier='other'">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
@@ -386,7 +436,7 @@
                     </contributorName>
                 </xsl:element>
             </xsl:when>
-            <xsl:when test="not(@qualifier)"> 
+            <xsl:when test="not(@qualifier)">
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
@@ -396,24 +446,24 @@
             </xsl:when>
         </xsl:choose>
     </xsl:template>
-    -->
+    End UMD Customization -->
 
-    <!--
+    <!-- UMD Customization
         DataCite (8), DataCite (8.1)
         Adds Date and dateType information
-    <xsl:template match="//dspace:field[@mdschema='dc' and @element='date' and 
-                        (@qualifier='accessioned' 
-                         or @qualifier='available' 
-                         or @qualifier='copyright' 
-                         or @qualifier='created' 
-                         or @qualifier='issued' 
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='date' and
+                        (@qualifier='accessioned'
+                         or @qualifier='available'
+                         or @qualifier='copyright'
+                         or @qualifier='created'
+                         or @qualifier='issued'
                          or @qualifier='submitted'
                          or @qualifier='updated')]">
-    	<xsl:if test="@qualifier='accessioned' 
-                        or @qualifier='available' 
-                        or @qualifier='copyright' 
-                        or @qualifier='created' 
-                        or @qualifier='issued' 
+    	<xsl:if test="@qualifier='accessioned'
+                        or @qualifier='available'
+                        or @qualifier='copyright'
+                        or @qualifier='created'
+                        or @qualifier='issued'
                         or @qualifier='submitted'
                         or @qualifier='updated'">
             <xsl:element name="date">
@@ -432,13 +482,13 @@
                 <xsl:if test="@qualifier='issued'">
                     <xsl:attribute name="dateType">Issued</xsl:attribute>
                 </xsl:if>
-    -->
+    End UMD Customization -->
                 <!-- DSpace recommends to use dc.date.submitted for theses and/or
-                     dissertations. DataCite uses submitted for the "date the 
+                     dissertations. DataCite uses submitted for the "date the
                      creator submits the resource to the publisher". -->
-    <!--
+    <!-- UMD Customization
                 <xsl:if test="@qualifier='submitted'">
-                    <xsl:attribute name="dateType">Issued</xsl:attribute>
+                    <xsl:attribute name="dateType">Submitted</xsl:attribute>
                 </xsl:if>
                 <xsl:if test="@qualifier='updated'">
                     <xsl:attribute name="dateType">Updated</xsl:attribute>
@@ -447,9 +497,9 @@
             </xsl:element>
 	</xsl:if>
     </xsl:template>
-    -->
+    End UMD Customization -->
 
-    <!-- 
+    <!--
         DataCite (9)
         Adds Language information
         Transforming the language flags according to IETF BCP 47 or ISO 639-1
@@ -467,7 +517,7 @@
         </xsl:element>
     </xsl:template>
 
-    <!-- 
+    <!--
         DataCite (10), DataCite (10.1)
         Adds resourceType and resourceTypeGeneral information
     -->
@@ -476,9 +526,9 @@
             <xsl:attribute name="resourceTypeGeneral">
                 <xsl:choose>
                     <xsl:when test="string(text())='Animation'">Audiovisual</xsl:when>
-                    <xsl:when test="string(text())='Article'">Text</xsl:when>
-                    <xsl:when test="string(text())='Book'">Text</xsl:when>
-                    <xsl:when test="string(text())='Book chapter'">Text</xsl:when>
+                    <xsl:when test="string(text())='Article'">JournalArticle</xsl:when>
+                    <xsl:when test="string(text())='Book'">Book</xsl:when>
+                    <xsl:when test="string(text())='Book chapter'">BookChapter</xsl:when>
                     <xsl:when test="string(text())='Dataset'">Dataset</xsl:when>
                     <xsl:when test="string(text())='Learning Object'">InteractiveResource</xsl:when>
                     <xsl:when test="string(text())='Image'">Image</xsl:when>
@@ -486,25 +536,27 @@
                     <xsl:when test="string(text())='Map'">Model</xsl:when>
                     <xsl:when test="string(text())='Musical Score'">Other</xsl:when>
                     <xsl:when test="string(text())='Plan or blueprint'">Model</xsl:when>
-                    <xsl:when test="string(text())='Preprint'">Text</xsl:when>
-                    <xsl:when test="string(text())='Presentation'">Text</xsl:when>
+                    <xsl:when test="string(text())='Preprint'">Preprint</xsl:when>
+                    <xsl:when test="string(text())='Presentation'">Other</xsl:when>
                     <xsl:when test="string(text())='Recording, acoustical'">Sound</xsl:when>
                     <xsl:when test="string(text())='Recording, musical'">Sound</xsl:when>
                     <xsl:when test="string(text())='Recording, oral'">Sound</xsl:when>
                     <xsl:when test="string(text())='Software'">Software</xsl:when>
-                    <xsl:when test="string(text())='Technical Report'">Text</xsl:when>
-                    <xsl:when test="string(text())='Thesis'">Text</xsl:when>
+                    <xsl:when test="string(text())='Technical Report'">Report</xsl:when>
+                    <xsl:when test="string(text())='Thesis'">Dissertation</xsl:when>
                     <xsl:when test="string(text())='Video'">Audiovisual</xsl:when>
                     <xsl:when test="string(text())='Working Paper'">Text</xsl:when>
                     <xsl:when test="string(text())='Other'">Other</xsl:when>
+                    <!-- UMD Customization -->
                     <xsl:otherwise>Collection</xsl:otherwise>
+                    <!-- End UMD Customization -->                    
                 </xsl:choose>
             </xsl:attribute>
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
 
-    <!--
+    <!-- UMD Customization
         DataCite (11), DataCite (11.1)
         Adds AlternativeIdentifier and alternativeIdentifierType information
         Adds all identifiers except the doi.
@@ -514,7 +566,7 @@
         AlternativeIdentifiers by using HandleManager.
         resolveUrlToHandle(context, altId) until one is recognized or all have
         been tested.
-    <xsl:template match="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]">
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(contains(., $prefix))]">
         <xsl:element name="alternateIdentifier">
             <xsl:if test="@qualifier">
                 <xsl:attribute name="alternateIdentifierType"><xsl:value-of select="@qualifier" /></xsl:attribute>
@@ -522,7 +574,7 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-    -->
+    End UMD Customization -->
 
     <!--
         DataCite (12), DataCite (12.1)
@@ -532,7 +584,7 @@
         Skip the related identifier until we find a proper solution.
     -->
 
-    <!--
+    <!-- UMD Customization
         DataCite (13)
         Adds Size information
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='format' and @qualifier='extent']">
@@ -540,9 +592,9 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-    -->
+     End UMD Customization -->
 
-    <!--
+    <!-- UMD Customization
         DataCite (14)
         Adds Format information
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='format'][not(@qualifier='extent')]">
@@ -550,8 +602,8 @@
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-    -->
-    
+    End UMD Customization -->
+
     <!--
         DataCite (15)
         Version information.
@@ -559,41 +611,34 @@
         the version information too.
     -->
 
-    <!--
+    <!-- UMD Customization
         DataCite (16)
         Adds Rights information
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='rights']">
-        <xsl:choose>
-            <xsl:when test="@qualifier='uri'">
-                <xsl:element name="rights">
-                    <xsl:attribute name="rightsURI">
-                        <xsl:value-of select="." />
-                    </xsl:attribute>
-                </xsl:element>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:element name="rights">
-                    <xsl:value-of select="." />
-                </xsl:element>
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:element name="rights">
+            <xsl:value-of select="." />
+        </xsl:element>
     </xsl:template>
-    -->
+    End UMD Customization -->
 
-    <!-- 
+    <!--
         DataCite (17)
         Description
     -->
+    <!-- UMD Customization -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='description' and (@qualifier='abstract' or not(@qualifier))]">
         <xsl:element name="description">
+            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
             <xsl:attribute name="descriptionType">
            	<xsl:choose>
                     <xsl:when test="@qualifier='abstract'">Abstract</xsl:when>
+                    <!-- <xsl:when test="@qualifier='tableofcontents'">TableOfContents</xsl:when> -->
                	    <xsl:otherwise>Other</xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>
             <xsl:value-of select="." />
         </xsl:element>
     </xsl:template>
-    
+    <!-- End UMD Customization -->
+
 </xsl:stylesheet>

--- a/dspace/docs/DrumDOI.md
+++ b/dspace/docs/DrumDOI.md
@@ -13,6 +13,14 @@ This document focuses on the customizations made for DRUM.
 DRUM uses the DataCite "MDS" API to mint DOIs. See
 <https://support.datacite.org/docs/mds-api-guide>
 
+## DataCite Schema
+
+DRUM uses a custom file, "dspace/config/crosswalks/DIM2UmdDataCite.xsl", to
+convert DSpace metadata into the DataCite schema. This file is based on the
+stock "dspace/config/crosswalks/DIM2DataCite.xsl" file, and configured for use
+in the `crosswalk.dissemination.DataCite.stylesheet` property of the "local.cfg"
+file.
+
 ## Random DOIs
 
 By default, DSpace creates ("mints") DOIs as integers that increment


### PR DESCRIPTION
Incorporated the DataCite Schema 4.5 changes made in DSpace 7.6.2 to the stock "DIM2DataCite.xsl" file
into the "DIM2UmdDataCite.xsl" while preserving UMD customizations.

https://umd-dit.atlassian.net/browse/LIBDRUM-866
