### PR TITLE
LIBDRUM-876. Modifications to the DRUM Submission Form

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -53,10 +53,10 @@
         <name-map collection-handle="123456789/29" submission-name="JournalVolume"/>
         <name-map collection-handle="123456789/30" submission-name="JournalIssue"/>
         -->
-        <!-- These configurations enable default submission forms per Entity type 
-            
+        <!-- These configurations enable default submission forms per Entity type
+
             The  collection-entity-type will be the entity-type attribute associated with a collection,
-            typically the entity name that is associated with a collection if any created or loaded 
+            typically the entity name that is associated with a collection if any created or loaded
             (that is usually specified in relationship-types.xml).
             - - - - - -
             PLEASE NOTICE THAT YOU WILL HAVE TO RESTART DSPACE
@@ -239,6 +239,19 @@
         </step-definition>
 
         <!-- UMD Customization -->
+        <!-- LIBDRUM-876 -->
+        <step-definition id="umdType" mandatory="true">
+          <heading>submit.progressbar.describe.umdType</heading>
+          <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+          <type>submission-form</type>
+        </step-definition>
+
+        <step-definition id="mhheaType" mandatory="true">
+          <heading>submit.progressbar.describe.mhheaType</heading>
+          <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+          <type>submission-form</type>
+        </step-definition>
+
         <step-definition id="umdDescribe" mandatory="true">
             <heading>submit.progressbar.describe.stepone</heading>
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
@@ -252,13 +265,6 @@
             <type>upload</type>
         </step-definition>
 
-        <!-- LIBDRUM-711 -->
-        <step-definition id="equitableAccessSubmission">
-            <heading>submit.progressbar.equitableAccessSubmission</heading>
-            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
-            <type>submission-form</type>
-            <scope>submission</scope>
-        </step-definition>
         <!-- End UMD Customization -->
     </step-definitions>
 
@@ -422,7 +428,7 @@
         <!-- UMD default submission process -->
         <submission-process name="umd-submission">
             <step id="collection"/>
-            <step id="equitableAccessSubmission"/>
+            <step id="umdType"/>
             <step id="umdDescribe"/>
             <step id="upload"/>
             <step id="cclicense"/>
@@ -434,6 +440,7 @@
             collection -->
         <submission-process name="MHHEA-submission">
             <step id="collection"/>
+            <step id="mhheaType"/>
             <step id="umdDescribe"/>
             <step id="optionalUpload"/>
             <step id="cclicense"/>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1349,25 +1349,8 @@
         </form>
 
         <!-- UMD Customization -->
-        <!-- Equitable access submission form -->
-        <form name="equitableAccessSubmission">
-            <row>
-                <field>
-                    <dc-schema>local</dc-schema>
-                    <dc-element>equitableAccessSubmission</dc-element>
-                    <dc-qualifier></dc-qualifier>
-                    <repeatable>false</repeatable>
-                    <label>Equitable Access</label>
-                    <input-type value-pairs-name="yes_no">dropdown</input-type>
-                    <hint>This item is being submitted to comply with the "Equitable Access to Scholarly Articles Authored by University Faculty" (https://equitableaccess.umd.edu/) policy.</hint>
-                    <required>Please select "Yes" or "No"</required>
-                </field>
-            </row>
-        </form>
-
-        <!-- Default "Describe" form for UMD submissions. Used for both
-             default and MHHEA submissions -->
-        <form name="umdDescribe">
+        <!-- "Type" field (with Equitable Access question) for default UMD submissions -->
+        <form name="umdType">
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>
@@ -1381,6 +1364,45 @@
                     <required>Please select a type for this item.</required>
                 </field>
             </row>
+
+            <row>
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>equitableAccessSubmission</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Equitable Access</label>
+                    <input-type value-pairs-name="yes_no">dropdown</input-type>
+                    <hint>This item is being submitted to comply with the "Equitable Access to Scholarly Articles Authored by University Faculty" (https://equitableaccess.umd.edu/) policy.</hint>
+                    <required>Please select "Yes" or "No"</required>
+                    <type-bind>
+                        <!-- Should only display for "Article" -->
+                        Article
+                    </type-bind>
+                </field>
+            </row>
+        </form>
+
+        <!-- "Type" field (without Equitable Access question) for MHHEA submissions -->
+        <form name="mhheaType">
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>type</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Type</label>
+                    <input-type value-pairs-name="umd_common_types">dropdown</input-type>
+                    <hint>Select the type of content of the item.
+                    </hint>
+                    <required>Please select a type for this item.</required>
+                </field>
+            </row>
+        </form>
+
+        <!-- Default "Describe" form for UMD submissions. Used for both
+             default and MHHEA submissions -->
+        <form name="umdDescribe">
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1659,7 +1659,7 @@
                     <repeatable>true</repeatable>
                     <label>Subject Keywords</label>
                     <input-type>onebox</input-type>
-                    <hint>Enter appropriate subject keywords or phrases.</hint>
+                    <hint>Enter appropriate subject keywords or phrases. To add multiple subject keywords, enter one term or phrase at a time and then click "Add more".</hint>
                     <required></required>
                 </field>
             </row>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1371,9 +1371,9 @@
                     <dc-element>equitableAccessSubmission</dc-element>
                     <dc-qualifier></dc-qualifier>
                     <repeatable>false</repeatable>
-                    <label>Equitable Access</label>
+                    <label>Is this article being submitted to comply with the "Equitable Access to Scholarly Articles Authored by University Faculty" (https://equitableaccess.umd.edu/) policy?</label>
                     <input-type value-pairs-name="yes_no">dropdown</input-type>
-                    <hint>This item is being submitted to comply with the "Equitable Access to Scholarly Articles Authored by University Faculty" (https://equitableaccess.umd.edu/) policy.</hint>
+                    <hint></hint>
                     <required>Please select "Yes" or "No"</required>
                     <type-bind>
                         <!-- Should only display for "Article" -->

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1409,9 +1409,9 @@
                     <dc-element>contributor</dc-element>
                     <dc-qualifier>author</dc-qualifier>
                     <repeatable>true</repeatable>
-                    <label>Author</label>
+                    <label>Author (Last Name, First Name)</label>
                     <input-type>onebox</input-type>
-                    <hint>Enter the author's name (Family name, Given names).</hint>
+                    <hint>Enter the author's name (Last name, First name).</hint>
                     <required>You must enter an author for this item.</required>
                 </field>
             </row>
@@ -1421,9 +1421,9 @@
                     <dc-element>contributor</dc-element>
                     <dc-qualifier>advisor</dc-qualifier>
                     <repeatable>true</repeatable>
-                    <label>Advisor</label>
+                    <label>Advisor (Last Name, First Name)</label>
                     <input-type>onebox</input-type>
-                    <hint>Enter the advisor's name (Family name, Given names).</hint>
+                    <hint>Enter the advisor's name (Last name, First name).</hint>
                     <required></required>
                 </field>
             </row>

--- a/dspace/docs/DrumEmbargoAndAccessRestrictions.md
+++ b/dspace/docs/DrumEmbargoAndAccessRestrictions.md
@@ -5,6 +5,9 @@
 This page describes the DRUM Embargo functionality and other access
 restrictions, as of DSpace 7.
 
+For changes to the submission form, see
+[dspace/docs/DrumSubmissionForms.md](DrumSubmissionForms.md).
+
 ## Useful Resources
 
 * <https://wiki.lyrasis.org/display/DSDOC7x/Embargo>

--- a/dspace/docs/DrumFeatures.md
+++ b/dspace/docs/DrumFeatures.md
@@ -54,6 +54,9 @@ for additional information
 * LIBDRUM-679 - Added "Embargo List" page for administrators reporting all the
   embargoed bitstreams, and enabling CSV download for administrators.
 
+See also the changes to the submission form in detailed in
+[dspace/docs/DrumSubmissionForms.md](DrumSubmissionForms.md).
+
 ## Email Templates
 
 The email templates in "dspace/config/emails" have been modified to use the
@@ -63,35 +66,15 @@ lines and signatures.
 
 ## Submissions
 
-* LIBDRUM-675 - For default submission workflow:
-  * "Author" field is required
-  * "Advisor" field added
-  * See also LIBDRUM-728
-
-* LIBDRUM-711 - "Equitable Access" field added to default submission form
-  * Automatically maps Equitable Access-submitted materials to the
-    "Equitable Access" group.
-
-* LIBDRUM-727 - "Creative Commons" license field added to submission form
-
-* LIBDRUM-729 - List of available types for "Type"  was simplified from DSpace
-  defaults
-
-* LIBDRUM-747 - "Modifying access conditions" section allowing users to create
-  item embargoes was removed.
+See [dspace/docs/DrumSubmissionForms.md](DrumSubmissionForms.md).
 
 ## Data Community
 
-* LIBDRUM-682:
-  * Modified submission form fields based on item type of "Dataset" or
-    "Software"
-  * "Dataset" or "Software" items automatically mapped to "UMD Data Community"
+See [dspace/docs/DrumSubmissionForms.md](DrumSubmissionForms.md).
 
 ## Minority Health and Health Equity Archive (MHHEA)
 
-* LIBDRUM-684 - Created custom workflow and submission form for submissions to
-  the MHHEA group
-* See also LIBDRUM-728
+See [dspace/docs/DrumSubmissionForms.md](DrumSubmissionForms.md).
 
 ## Community Groups
 

--- a/dspace/docs/DrumSubmissionForms.md
+++ b/dspace/docs/DrumSubmissionForms.md
@@ -1,0 +1,174 @@
+# DRUM Submission Forms
+
+## Introduction
+
+This document describes the DRUM customizations to the DSpace item submission
+process.
+
+## Jira Issues
+
+* LIBDRUM-675
+* LIBDRUM-682
+* LIBDRUM-684
+* LIBDRUM-711
+* LIBDRUM-727
+* LIBDRUM-728
+* LIBDRUM-729
+* LIBDRUM-747
+* LIBDRUM-876
+
+## Submission Forms
+
+### Default and MHHEA submissions
+
+The DRUM item submission process provides two separate submission forms, based
+on the collection the item is being submitted to.
+
+The "MHHEA" submission form is only used for item submissions to the
+"Minority Health and Health Equity Archive" (MHHEA) collection.
+
+The "default" submission form is used for all other collections.
+
+### Default Submission Form
+
+#### Required Fields
+
+DRUM customized the submission form to require the following fields:
+
+* Author
+* Type
+
+These fields are in addition to those required by stock DSpace:
+
+* Date of Issue
+* File Upload
+
+#### Additions
+
+The following fields were added to the submission form:
+
+* Advisor
+* External Link
+
+The DSpace-provided "Creative Commons license" step was added to the submission
+form.
+
+#### Modifications
+
+The following fields were modified from their DSpace defaults:
+
+* Subject - modified to be a repeatable text box, instead of the stock "tag"
+  field that uses a controlled vocabulary.
+* Type - The entries in the drop-down use a UMD-customized list
+* The embargo-related fields in the "Edit bitstream" modal dialog were removed
+  (additional information about embargoes is in
+  [dspace/docs/DrumEmbargoAndAccessRestrictions.md](DrumEmbargoAndAccessRestrictions.md)):
+
+  * Access condition type
+  * Grant access from
+  * Grant access until
+
+### MHHEA submission form
+
+The MHHEA submission form differs from the default form in the following ways:
+
+* the "Equitable Access" field is never displayed, and submissions are never
+  added to the "Equitable Access Policy" collection
+* File uploads are not required
+
+## Data Community
+
+Items with a "Type" field of "Dataset" or "Software" are automatically
+added to the "UMD Data Collection" collection.
+
+This behavior applies to both the default and MHHEA submission forms.
+
+The "Data Community" functionality includes the following customizations to
+DSpace:
+
+### Data Community Submission Form Changes
+
+Submission form fields removed when "Dataset" or "Software" is selected:
+
+* dc.relation.ispartofseries - Series/Report No.
+* dc.identifier - Identifiers
+
+Submission form field label changes when "Dataset" or "Software" is selected:
+
+* dc.identifier.citation - "Publication Citation" changed to
+   "Related Publication Citation"
+* dc.descripton.uri - "Publication or External Link" changed to
+  "Related Publication Link"
+* dc.description - "Description" changed to "Methodology Description"
+
+### Data Community Mapping
+
+The "dspace/modules/additions/src/main/java/edu/umd/lib/dspace/xmlworkflow/state/actions/DataCommunityCollectionMappingAction.java"
+class supports mapping an item to the "UMD Data Collection" community. The
+class will map the item into every collection held by the
+"UMD Data Collection" community (this is in line with how mappings were done in
+DSpace 6).
+
+The "UMD Data Collection" community is specified by the
+"data.community.handle" property in "dspace/config/local.cfg".
+
+### Data Community Workflow
+
+The "/dspace/config/spring/api/workflow-actions.xml" was modified to add
+the "datacommunitycollectionmappingaction" WorkflowActionConfig bean, and
+a "dataCommunityCollectionMappingAPI" bean configured to use the
+"DataCommunityCollectionMappingAction" class.
+
+A "umdcollectionmapping" step was added to the end of the "defaultWorkflow"
+steps, and modified the "finaleditstep" to go to the "umdcollectionmapping" when
+it completes. Modifying the "finaleditstep" appears to be necessary –
+despite how it may seem from the documentation - as the workflow steps to not
+naturally progress through all the steps in the list.
+
+## Equitable Access
+
+The "Equitable Access" functionality includes the following customizations to
+DSpace:
+
+### Equitable Access Submission Form Changes
+
+Both the default and MHHEA submission forms have a "Submission Type" step that
+contains the "Type" field.
+
+In the default submission form, selecting "Article" in the "Type" field
+dynamically displays the "Equitable Access" field.
+
+In the MHHEA form, the "Equitable Access" field is never displayed, as MHHEA
+submissions are never added to the "Equitable Access Policy" collection.
+
+### "local.equitableAccessSubmission" metadata field
+
+A "local.equitableAccessSubmission" metadata field was added to track the user's
+response to the "Equitable Access" question on the submission form. This
+metadata field (with a "Yes" or "No" response) shows up in the "Full item page"
+view for the item.
+
+### Equitable Access Community Mapping
+
+The "dspace/modules/additions/src/main/java/edu/umd/lib/dspace/xmlworkflow/state/actions/EquitableAccessCollectionMappingAction.java"
+class supports mapping an item to the "Equitable Access Policy" community. The
+class will map the item into every collection held by the
+"Equitable Access Policy" community (this is in line with how Data Community
+mappings were done in DSpace 6).
+
+The "Equitable Access Policy" community is specified by the
+"equitable_access_policy.community.handle" property in
+"dspace/config/local.cfg".
+
+### Equitable Access Workflow
+
+The "/dspace/config/spring/api/workflow-actions.xml" was modified to add
+the "equitableaccesscollectionmappingaction" WorkflowActionConfig bean, and
+a "equitableAccessCollectionMappingAPI" bean configured to use the
+"EquitableAccessCollectionMappingAction" class.
+
+A "umdcollectionmapping" step was added to the end of the "defaultWorkflow"
+steps, and modified the "finaleditstep" to go to the "umdcollectionmapping" when
+it completes. Modifying the "finaleditstep" appears to be necessary –
+despite how it may seem from the documentation - as the workflow steps to not
+naturally progress through all the steps in the list.


### PR DESCRIPTION
## Make "Equitable Access" field dynamic based on "Type"

For the default submission form, created a "Submission Type" step ("umdType") and associated form to enable the "Equitable Access" field to be dynamically displayed/hidden based on whether "Article" was chosen in the "Type" dropdown.

This also required creating a separate "Submission Type" step ("mhheaType") and associated form to display the "Type" field without the "Equitable Access" field, since MHHEA submissions are never use the "Equitable Access" mapping.

Splitting the “Type” field into a separate form step was is necessary, because in the “Minority Health and Health Equity Archive” submission process, the “Equitable Access” field should not be displayed on MHHEA submissions (even it “Article” is selected). DSpace does not provide the functionality to display/hide fields on a per-collection basis – it can only do so on the basis of form steps. This means that we need to have a one form step to handle the “Type”/”Equitable Access” fields for the normal submissions, and a separate form step with just the “Type” field for the MHHEA submissions.

Removed the "equitableAccessSubmission" step and associated form, as it is no longer used.

## Added "DrumSubmissionForms.md" Markdown document

Attempted to consolidate the information about the DRUM submission forms into a single "DrumSubmissionsForms.md" document.

Updated other documentation with links to the "DrumSubmissionsForms.md" document.

## Modified Author/Advisor label for desired placeholder text

DSpace does not have the ability to set the placeholder text on form fields. Instead, it simply reuses the label for the field.

Terry Owen requested that the "Author" and "Advisor" placeholder text be changed to "Last Name, First Name", in order to prompt users to enter names in that order.

Since it is not currently possible set the placeholder text separately from the label, changed the labels to:

* Author (Last Name, First Name)
* Advisor (Last Name, First Name)

which also changes the placeholder text.

## Adjust "Subject" field hint

Adjusted the "Subject" field hint based on a request from Terry Owen, with a goal of getting people not to put all their subject keywords into a single entry.

## Replaced "Equitable Access" label with explanatory text

Terry Owen in https://umd-dit.atlassian.net/browse/LIBDRUM-876?focusedCommentId=348080 requested that text be placed between the "Equitable Access" label and the textbox, but this was not possible with the stock DSpace implementation. So instead, replaced the entire "Equitable Access" label with the desired text, and removed the redundant "hint" text.

https://umd-dit.atlassian.net/browse/LIBDRUM-876