### PR TITLE
LIBDRUM-901. Provide JSON logging configuration for Kubernetes

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -341,6 +341,13 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
+        <!-- UMD Customization -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- End UMD Customization -->
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>

--- a/dspace/docs/DrumLogging.md
+++ b/dspace/docs/DrumLogging.md
@@ -1,0 +1,132 @@
+# DRUM Logging
+
+## Introduction
+
+This document describes DRUM customizations to the DSpace logging configuration.
+
+DRUM customizes DSpace to enable JSON-formatted log entries when using
+Kubernetes, as it enables more flexible search options when using Splunk.
+
+By default, DSpace configures the Spring Boot embedded Tomcat server to use the
+Log4j2 logging framework, via the
+"org.springframework.boot:spring-boot-starter-log4j2" Maven dependency, in
+preference to the stock Spring Boot "logback" framework.
+
+## DSpace Logs
+
+There are two distinct log configurations:
+
+* DSpace application logs
+* Spring Boot embedded Tomcat server access logs
+
+## Local Development Environment Logging
+
+In the local development environment, DSpace is run via Docker Compose, and
+the DSpace application logs are controlled by the
+"dspace/config/log4j2-container.xml" file.
+
+The Tomcat server access logs are controlled by Spring Boot. The default
+Spring Boot configuration, which does not enable the Tomcat server access log,
+is typically used, but can be managed by Spring Boot "server.tomcat.accesslog.*"
+properties in the "dspace/config/local.cfg", see
+<https://docs.spring.io/spring-boot/docs/3.2.6/reference/html/application-properties.html#appendix.application-properties.server>.
+
+To enable JSON-formatted logging (similar to how logs are displayed in
+Kubernetes), do the following:
+
+1) In "dspace/config/log4j2-container.xml", replace the "PatternLayout"
+   stanza in the "A1" appender:
+
+    ```xml
+            <Appender name='A1'
+                      type='Console'
+                <JsonTemplateLayout eventTemplateUri="classpath:EcsLayout.json" />
+           </Appender>
+    ```
+
+   This will enable JSON-formatted logging for the DSpace application logs.
+
+2) Add the following to "dspace/config/local.cfg" to enable the Tomcat access
+   logs (in JSON format):
+
+   ```text
+   # Tomcat access log
+   # Set umd.server.tomcat.accesslog.json.enabled to "true" for JSON logging
+   umd.server.tomcat.accesslog.json.enabled=true
+   # Set server.tomcat.accesslog.enabled to "true" for common logging
+   #server.tomcat.accesslog.enabled=true
+   server.tomcat.accesslog.directory=/dev
+   server.tomcat.accesslog.prefix=stdout
+   server.tomcat.accesslog.buffered=false
+   server.tomcat.accesslog.suffix=
+   server.tomcat.accesslog.file-date-format=
+   server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D
+   ```
+
+## Kubernetes JSON-formatted Logging
+
+In Kubernetes, the DSpace application logs are controlled by the
+"overlays/\<NAMESPACE>/log4j2.xml" file (where "\<NAMESPACE>" is the Kubernetes
+namespace (i.e., "sandbox", "test", "qa", or "prod").
+
+To enable JSON-formatted logging, the Log4j "Appenders" are modified to use
+the "JsonTemplateLayout", i.e.:
+
+```xml
+        <Appender name='A1'
+                  type='Console'
+            <JsonTemplateLayout eventTemplateUri="classpath:EcsLayout.json" />
+        </Appender>
+```
+
+The JSON-formatted Tomcat access log in enabled by the
+"umd.server.tomcat.accesslog.json.enabled" property in the
+"overlays/\<NAMESPACE>/local.cfg" file:
+
+```text
+# Tomcat access log
+umd.server.tomcat.accesslog.json.enabled=true
+server.tomcat.accesslog.directory=/dev
+server.tomcat.accesslog.prefix=stdout
+server.tomcat.accesslog.buffered=false
+server.tomcat.accesslog.suffix=
+server.tomcat.accesslog.file-date-format=
+server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D
+```
+
+## DRUM Customizations
+
+To enable JSON-formatted logging, the embedded Tomcat server provided by Spring
+Boot must be modified to use a "org.apache.catalina.valves.JsonAccessLogValve"
+valve instead of the default "org.apache.catalina.valves.AccessLogValve".
+
+In a non-embedded Tomcat server, the "JsonAccessLogValve" would be configured
+via the Tomcat's "server.xml" configuration file. When using the Spring Boot
+embedded Tomcat server, this file is not available, and instead an
+implementation of the Spring Boot
+"org.springframework.boot.web.server.WebServerFactoryCustomizer" class is used,
+see <https://docs.spring.io/spring-boot/docs/3.2.6/reference/html/howto.html#howto.webserver.configure>.
+
+The "dspace/modules/server-boot/src/main/java/org/dspace/app/UmdTomcatWebServerFactoryCustomizer.java"
+class provides the "WebServerFactoryCustomizer" implementation necessary to
+configure the Spring Boot embedded Tomcat server to use the
+"JsonAccessLogValve".
+
+The "dspace/modules/server-boot/src/main/java/org/dspace/app/ServerBootApplication.java"
+class has been customized to include the "UmdTomcatWebServerFactoryCustomizer"
+class has part of its configuration.
+
+## log4j-layout-template-json Dependency
+
+The "JsonTemplateLayout" used in the Log4J appender is provided by the
+"org.apache.logging.log4j:log4j-layout-template-json" Maven dependency.
+
+In order for the "JsonTemplateLayout" class to be available to both the
+Spring Boot embedded Tomcat server, and the DSpace Java application, the
+"log4j-layout-template-json" dependency has been added to the
+"dspace-api/pom.xml" file, as this gives it the earliest integration at
+startup.
+
+If JSON formatting is only needed for the embedded Tomcat server, and *not*
+the DSpace application, the "log4j-layout-template-json" only needs to be added
+to the "dspace/modules/server-boot/pom.xml" file.

--- a/dspace/modules/server-boot/src/main/java/org/dspace/app/ServerBootApplication.java
+++ b/dspace/modules/server-boot/src/main/java/org/dspace/app/ServerBootApplication.java
@@ -12,16 +12,22 @@ import org.dspace.app.rest.utils.DSpaceConfigurationInitializer;
 import org.dspace.app.rest.utils.DSpaceKernelInitializer;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+// UMD Customization
+import org.springframework.context.annotation.Import;
+// End UMD Customization
 
 /**
  * Define the Spring Boot Application settings itself to be runned using an
  * embedded application server.
- * 
+ *
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
 @SuppressWarnings({ "checkstyle:hideutilityclassconstructor" })
 @SpringBootApplication(scanBasePackageClasses = WebApplication.class)
+// UMD Customization
+@Import({ UmdTomcatWebServerFactoryCustomizer.class })
+// End UMD Customization
 public class ServerBootApplication {
 
     public static void main(String[] args) {

--- a/dspace/modules/server-boot/src/main/java/org/dspace/app/UmdTomcatWebServerFactoryCustomizer.java
+++ b/dspace/modules/server-boot/src/main/java/org/dspace/app/UmdTomcatWebServerFactoryCustomizer.java
@@ -1,0 +1,83 @@
+package org.dspace.app;
+
+import org.apache.catalina.valves.JsonAccessLogValve;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties.Tomcat.Accesslog;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+/**
+ * UMD customization of the Spring Boot embedded Tomcat Server
+ */
+@Component
+public class UmdTomcatWebServerFactoryCustomizer implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    private final ServerProperties serverProperties;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    public UmdTomcatWebServerFactoryCustomizer(ServerProperties serverProperties) {
+        this.serverProperties = serverProperties;
+    }
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        provideJsonLogging(factory);
+    }
+
+    /**
+     * Adds the JsonAccessLogValve to the Tomcat configuration, enabling logs
+     * to be output in the JSON format.
+     *
+     * The valve is enabled by a UMD custom
+     * "umd.server.tomcat.accesslog.json.enabled" property
+     *
+     * A custom  property, instead of the Spring Boot standard
+     * "server.tomcat.accesslog.enabled" property is used to prevent
+     * double-logging from the stock Spring Book AccessLogValve
+     *
+     * @param factory the TomcatServletWebServerFactory to configure
+     */
+    protected void provideJsonLogging(TomcatServletWebServerFactory factory) {
+        // Control enabling of the JsonAccessLogValve based on UMD custom
+        // "umd.server.tomcat.accesslog.json.enabled" property, instead of
+        // the Spring Boot standard "server.tomcat.accesslog.enabled" to prevent
+        // double-logging from the stock Spring Book AccessLogValve
+        boolean jsonLoggerEnabled = Boolean
+                .parseBoolean(configurationService.getProperty("umd.server.tomcat.accesslog.json.enabled", "false"));
+
+        // Set JsonAccessLogValve settings from standard Spring Boot
+        // server properties.
+        //
+        // Copied from spring-boot-project/spring-boot-autoconfigure/
+        //   src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+        ServerProperties.Tomcat tomcatProperties = this.serverProperties.getTomcat();
+        JsonAccessLogValve valve = new JsonAccessLogValve();
+        PropertyMapper map = PropertyMapper.get();
+        Accesslog accessLogConfig = tomcatProperties.getAccesslog();
+
+        map.from(accessLogConfig.getConditionIf()).to(valve::setConditionIf);
+        map.from(accessLogConfig.getConditionUnless()).to(valve::setConditionUnless);
+        map.from(accessLogConfig.getPattern()).to(valve::setPattern);
+        map.from(accessLogConfig.getDirectory()).to(valve::setDirectory);
+        map.from(accessLogConfig.getPrefix()).to(valve::setPrefix);
+        map.from(accessLogConfig.getSuffix()).to(valve::setSuffix);
+        map.from(accessLogConfig.getEncoding()).whenHasText().to(valve::setEncoding);
+        map.from(accessLogConfig.getLocale()).whenHasText().to(valve::setLocale);
+        map.from(accessLogConfig.isCheckExists()).to(valve::setCheckExists);
+        map.from(accessLogConfig.isRotate()).to(valve::setRotatable);
+        map.from(accessLogConfig.isRenameOnRotate()).to(valve::setRenameOnRotate);
+        map.from(accessLogConfig.getMaxDays()).to(valve::setMaxDays);
+        map.from(accessLogConfig.getFileDateFormat()).to(valve::setFileDateFormat);
+        map.from(accessLogConfig.isIpv6Canonical()).to(valve::setIpv6Canonical);
+        map.from(accessLogConfig.isRequestAttributesEnabled()).to(valve::setRequestAttributesEnabled);
+        map.from(accessLogConfig.isBuffered()).to(valve::setBuffered);
+        map.from(jsonLoggerEnabled).to(valve::setEnabled);
+
+        factory.addEngineValves(valve);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1644,6 +1644,13 @@
                 <artifactId>log4j-jul</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <!-- UMD Customization -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-layout-template-json</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <!-- End UMD Customization -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>


### PR DESCRIPTION
Added the "UmdTomcatWebServerFactoryCustomizer" class to configure the Spring Boot embedded Tomcat server with a JSON-formatting logger that can be activated by a custom
"umd.server.tomcat.accesslog.json.enabled" property.

The stock DSpace “ServerBootApplication.java” file was modified to import the “UmdTomcatWebServerFactoryCustomizer” class.

Added "log4j-layout-template-json" dependency to the "server-boot/pom.xml" file to provide necessary JSON support.

https://umd-dit.atlassian.net/browse/LIBDRUM-901