### PR TITLE
LIBDRUM-908. xml:lang underscore fix

### DIFF
--- a/dspace/config/crosswalks/DIM2UmdDataCite.xsl
+++ b/dspace/config/crosswalks/DIM2UmdDataCite.xsl
@@ -25,6 +25,10 @@
          to register DOIs anymore. Please follow and reuse the examples
          included in this file. For more information on the DataCite
          Schema, see https://schema.datacite.org. -->
+    <!-- Note regarding language codes: xml:lang regional language codes require a hyphen, whereas many
+         repositories use underscores when storing these language codes (e.g. en_GB, de_CH).
+         This template translates all underscores to hyphens when selecting value of @lang in an attribute
+         so the output will be e.g. xml:lang="en-GB", xml:lang="de-CH". -->
 
     <!-- We need the prefix to determine DOIs that were minted by ourself. -->
     <xsl:param name="prefix">10.5072/dspace-</xsl:param>
@@ -359,20 +363,20 @@
     <!-- DataCite (3) :: Title -->
     <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
         <xsl:element name="title">
-            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+            <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
             <xsl:if test="@qualifier='alternative'">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+                <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
                 <xsl:attribute name="titleType">AlternativeTitle</xsl:attribute>
             </xsl:if>
-            <!-- DSpace does include niehter a dc.title.subtitle nor a
+            <!-- DSpace doesn't include a dc.title.subtitle nor a
                  dc.title.translated. If necessary, please create those in the
                  metadata field registry. -->
             <xsl:if test="@qualifier='subtitle'">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+                <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
                 <xsl:attribute name="titleType">Subtitle</xsl:attribute>
             </xsl:if>
             <xsl:if test="@qualifier='translated'">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+                <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
                 <xsl:attribute name="titleType">TranslatedTitle</xsl:attribute>
             </xsl:if>
             <xsl:value-of select="." />
@@ -391,7 +395,7 @@
     -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='subject']">
         <xsl:element name="subject">
-            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+            <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
             <xsl:if test="@qualifier">
                 <xsl:attribute name="subjectScheme"><xsl:value-of select="@qualifier" /></xsl:attribute>
             </xsl:if>
@@ -628,7 +632,7 @@
     <!-- UMD Customization -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='description' and (@qualifier='abstract' or not(@qualifier))]">
         <xsl:element name="description">
-            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+            <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
             <xsl:attribute name="descriptionType">
            	<xsl:choose>
                     <xsl:when test="@qualifier='abstract'">Abstract</xsl:when>


### PR DESCRIPTION
Incorporate change from DSpace Pull Request 9796 to rewrite "xml:lang" attributes such as "en_US" to the DataCite required "en-US", as per https://www.w3.org/International/articles/language-tags/#region

https://umd-dit.atlassian.net/browse/LIBDRUM-908
