### PR TITLE
LIBDRUM-907. Fix ETD loader resource policy for embargoed bitstreams

### DIFF
--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/app/EtdLoader.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/app/EtdLoader.java
@@ -459,23 +459,20 @@ public class EtdLoader {
 
         if (strEmbargo.equals("never")) {
             log.info("Embargoed forever");
-            rp = resourcePolicyService.create(context, null, null);
+            rp = resourcePolicyService.create(context, null, etdgroup);
             rp.setAction(Constants.READ);
-            rp.setGroup(etdgroup);
             lPolicies.add(rp);
         } else {
             Date date = format.parse(strEmbargo);
             log.info("Embargoed until " + date);
 
-            rp = resourcePolicyService.create(context, null, null);
+            rp = resourcePolicyService.create(context, null, etdgroup);
             rp.setAction(Constants.READ);
-            rp.setGroup(etdgroup);
             rp.setEndDate(date);
             lPolicies.add(rp);
 
-            rp = resourcePolicyService.create(context, null, null);
+            rp = resourcePolicyService.create(context, null, anongroup);
             rp.setAction(Constants.READ);
-            rp.setGroup(anongroup);
             rp.setStartDate(date);
             lPolicies.add(rp);
         }


### PR DESCRIPTION
In DSpace 7.6.2 changes were made to the
“dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java” class, in which the “create” method was modified to include “EPerson” and “Group” parameters.

When originally updated for DSpace 7.6.2, the DRUM code set these parameters were set to “null” to satisfy the compiler (as the proper group was subsequently set using a “setGroup” method), but this ran afoul of the parameter checking in the “create” method, resulting in the error.

Corrected the issue by supplying the proper Group to the “create” method, and removed the subsequent “setGroup” calls, as they were no longer needed.

https://umd-dit.atlassian.net/browse/LIBDRUM-907
