### PR TITLE
LIBDRUM-915. Updated docker-compose.yml to support VS Code debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     - |
       while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
       /dspace/bin/dspace database migrate
-      java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
+      java $${JPDA_OPTS} -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
   # DSpace PostgreSQL database container
   dspacedb:
     container_name: dspacedb

--- a/dspace/docs/DockerDevelopmentEnvironment.md
+++ b/dspace/docs/DockerDevelopmentEnvironment.md
@@ -173,7 +173,7 @@ development:
 
 ## Debugging
 
-The `JAVA_TOOL_OPTIONS` configuration included in the Docker compose starts the
+The `JPDA_OPTS` configuration included in the Docker compose starts the
 JPDA debugger for Tomcat. The [.vscode/launch.json](/.vscode/launch.json)
 file contains the VS Code debug configuration needed to attach to Tomcat. See
 the "Visual Studio Code IDE Setup" section for the extensions needed for


### PR DESCRIPTION
In DSpace 7.6.2, the back-end was run using the Tomcat “catalina.sh” script, which automatically included the “JPDA_OPTS” environment variable, if present in the shell.

With the switch to using a Spring Boot embedded Tomcat server, the Tomcat server is started by a “java”  command, instead of the “catalina.sh” script.

Modified the “docker-compose.yml“ to use the “JPDA_OPTS” environment variable when starting the DRUM back-end, i.e. changed:

```yaml
    entrypoint:
      ...
      java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
```

to

```yaml
    entrypoint:
      ...
      java $${JPDA_OPTS} -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
```

The use of the ${{...} was suggested by https://stackoverflow.com/a/65564161

Updated the “DockerDevelopmentEnvironment.md” document to reference the “JPDA_OPTS” environment variable, instead of the non-existent “JAVA_TOOL_OPTIONS” environment variable.

https://umd-dit.atlassian.net/browse/LIBDRUM-915
