### PR TITLE
LIBDRUM-916. Purge DOIs with no associated bitstream before registration

### DIFF
--- a/dspace/docs/DrumDOI.md
+++ b/dspace/docs/DrumDOI.md
@@ -45,3 +45,26 @@ in standard DSpace, where it is assigned to the "dc.identifier.doi" field.
 We have disabled "doi-filter" filter config in the DOIIdentifierProvider in the
 [identifier-service.xml](../config/spring/api/identifier-service.xml) as it is
 not compatible with the our DOI generation workflow.
+
+## Item Deletion and DOIs
+
+DRUM has been customized to generate a DOI when an item is created, including
+placing an entry in the Postgres "doi" table.
+
+When an item is deleted, the DOI no longer has an associated item, but the entry
+still exists in the Postgres "doi" table, with a null "dspace_object" field.
+This is problematic if the DOI has not been registered, as the stock DSpace
+registration process expects the associated item to be non-null.
+
+This method for correcting the issue was chosen (instead of, for example,
+modifying the DSpace code to delete the DOI when the item was deleted), as it
+seemed the most straightforward, and only involved classes that UMD was already
+modifying for DRUM.
+
+To mitigate this issue, in the "DOIOrganiser" class, the "register-all" command
+has been modified to purge any DOIs in the "doi" table with a status of
+"TO_BE_REGISTERED", that do not a null associated item.
+
+See [LIBDRUM-915](https://umd-dit.atlassian.net/browse/LIBDRUM-915) and
+[LIBDRUM-914](https://umd-dit.atlassian.net/browse/LIBDRUM-914).
+

--- a/dspace/docs/DrumDOI.md
+++ b/dspace/docs/DrumDOI.md
@@ -56,15 +56,15 @@ still exists in the Postgres "doi" table, with a null "dspace_object" field.
 This is problematic if the DOI has not been registered, as the stock DSpace
 registration process expects the associated item to be non-null.
 
+To mitigate this issue, in the "DOIOrganiser" class, the "register-all" command
+has been modified to purge any DOIs in the "doi" table with a status of
+"TO_BE_REGISTERED" that do not an associated item.
+
 This method for correcting the issue was chosen (instead of, for example,
 modifying the DSpace code to delete the DOI when the item was deleted), as it
 seemed the most straightforward, and only involved classes that UMD was already
 modifying for DRUM.
 
-To mitigate this issue, in the "DOIOrganiser" class, the "register-all" command
-has been modified to purge any DOIs in the "doi" table with a status of
-"TO_BE_REGISTERED", that do not a null associated item.
-
-See [LIBDRUM-915](https://umd-dit.atlassian.net/browse/LIBDRUM-915) and
+See [LIBDRUM-916](https://umd-dit.atlassian.net/browse/LIBDRUM-916) and
 [LIBDRUM-914](https://umd-dit.atlassian.net/browse/LIBDRUM-914).
 

--- a/dspace/modules/additions/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -682,17 +682,19 @@ public class DOIOrganiser {
     /**
      * If the DOI is marked as TO_BE_REGISTERED or TO_BE_RESERVED locally, but it
      * already is reserved with the provider then it is possible that the randomly
-     * generated local DOI is not gloabally unique. This is possible if the
+     * generated local DOI is not globally unique. This is possible if the
      * same DOI was created with the provider external to this DSpace instance (From
      * a different application or manually)
      *
      * @see DOIIdentifierProvider#mintRandomUniqueDoi()
      * @see DOIIdentifierProvider#mintRandomGloballyUniqueDoi()
      *
-     * @param context
-     * @param doi
-     * @return
-     * @throws DOIIdentifierException
+     * @param context the current Context
+     * @param doi the DOI to check for uniqueness with the external provider
+     * @return true if the given DOI has already been reserved with the external
+     *         provider, false otherwise.
+     * @throws DOIIdentifierException if an error occurs setting the newly
+     *         minted DOi
      */
     private boolean isNonUniqueDoi(Context context, DOI doi) throws DOIIdentifierException {
         if (doi.getStatus() == null ||
@@ -710,10 +712,11 @@ public class DOIOrganiser {
     /**
      * Mint a new DOI that is unique both locally and in the provider system.
      *
-     * @param context
-     * @param doiRow
-     * @throws SQLException
-     * @throws DOIIdentifierException
+     * @param context the current Context
+     * @param doiRow the DOI to update with a globally unique DOI
+     * @throws SQLException if a database error occurs
+     * @throws DOIIdentifierException if an error occurs setting the newly
+     *         minted DOi
      */
     private void setNewDoi(Context context, DOI doiRow) throws SQLException, DOIIdentifierException {
         System.out.println("Minting new DOI for item with handle: " + doiRow.getDSpaceObject().getHandle());

--- a/dspace/modules/additions/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -238,6 +238,9 @@ public class DOIOrganiser {
 
         if (line.hasOption('r')) {
             try {
+                // UMD Customization
+                organiser.purgeEmptyDOIsWithStatus(context, DOIIdentifierProvider.TO_BE_REGISTERED);
+                // End UMD Customization
                 List<DOI> dois = doiService
                     .getDOIsByStatus(context, Arrays.asList(DOIIdentifierProvider.TO_BE_REGISTERED));
                 if (dois.isEmpty()) {
@@ -719,6 +722,30 @@ public class DOIOrganiser {
         System.out.println("Minted new unique DOI: " +  doiRow.getDoi() + " for item with handle " +
                 doiRow.getDSpaceObject().getHandle());
 
+    }
+
+    /**
+     * Deletes any DOIs with the given status that do not have an associated
+     * DSpace object.
+     *
+     * This can occur, for example, when a DSpace object is deleted, as DOIs
+     * do not appear to be updated by DSpace object deletions.
+     *
+     * @param context the current Context
+     * @param status the DOIIdentifierProvider status to use in retrieving DOIs
+     * @throws SQLException if a database error occurs.
+     */
+    protected void purgeEmptyDOIsWithStatus(Context context, Integer status)
+        throws SQLException {
+        List<DOI> dois = doiService.getDOIsByStatus(context, Arrays.asList(status));
+        for (DOI doi: dois) {
+            if (doi.getDSpaceObject() == null) {
+                doiService.delete(context, doi);
+                context.uncacheEntity(doi);
+                System.out.println("Purged DOI: " +  doi.getDoi() +
+                    " as its associated DSpace object has been deleted.");
+            }
+        }
     }
     // End UMD Customization
 

--- a/dspace/modules/additions/src/test/java/org/dspace/identifier/doi/DOIOrganiserTest.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/identifier/doi/DOIOrganiserTest.java
@@ -1,0 +1,218 @@
+package org.dspace.identifier.doi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.identifier.DOI;
+import org.dspace.identifier.DOIIdentifierProvider;
+import org.dspace.identifier.factory.IdentifierServiceFactory;
+import org.dspace.identifier.service.DOIService;
+import org.dspace.utils.DSpace;
+import org.dspace.workflow.WorkflowException;
+import org.dspace.workflow.WorkflowItem;
+import org.dspace.workflow.factory.WorkflowServiceFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * UMD custom class for {@link DOIOrganiser} tests.
+ */
+public class DOIOrganiserTest
+    extends AbstractUnitTest {
+    /**
+     * log4j category
+     */
+    private static final Logger log = LogManager.getLogger(DOIOrganiserTest.class);
+
+    private static final String PREFIX = "10.5072";
+    private static final String NAMESPACE_SEPARATOR = "dspaceUnitTests-";
+
+    protected DOIService doiService = IdentifierServiceFactory.getInstance().getDOIService();
+    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
+
+
+    private static Community community;
+    private static Collection collection;
+
+    public DOIOrganiserTest() {
+    }
+
+    /**
+     * This method will be run before every test as per @Before. It will
+     * initialize resources required for the tests.
+     *
+     * Other methods can be annotated with @Before here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @Before
+    @Override
+    public void init() {
+        super.init();
+
+        try {
+            context.turnOffAuthorisationSystem();
+            // Create an environment for our test objects to live in.
+            community = communityService.create(null, context);
+            communityService.setMetadataSingleValue(context, community,
+                    CommunityService.MD_NAME, null, "A Test Community");
+            communityService.update(context, community);
+            collection = collectionService.create(context, community);
+            collectionService.setMetadataSingleValue(context, collection,
+                    CollectionService.MD_NAME, null, "A Test Collection");
+            collectionService.update(context, collection);
+            //we need to commit the changes so we don't block the table for testing
+            context.restoreAuthSystemState();
+        } catch (AuthorizeException ex) {
+            log.error("Authorization Error in init", ex);
+            fail("Authorization Error in init: " + ex.getMessage());
+        } catch (SQLException ex) {
+            log.error("SQL Error in init", ex);
+            fail("SQL Error in init: " + ex.getMessage());
+        }
+    }
+
+    /**
+     * This method will be run after every test as per @After. It will
+     * clean resources initialized by the @Before methods.
+     *
+     * Other methods can be annotated with @After here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @After
+    @Override
+    public void destroy() {
+        community = null;
+        collection = null;
+        super.destroy();
+    }
+
+    /**
+     * Create a fresh Item, installed in the repository.
+     *
+     * @throws SQLException       if database error
+     * @throws AuthorizeException if authorization error
+     * @throws IOException        if IO error
+     */
+    private Item newItem()
+        throws SQLException, AuthorizeException, IOException, IllegalAccessException, WorkflowException {
+        context.turnOffAuthorisationSystem();
+
+        WorkspaceItem wsItem = workspaceItemService.create(context, collection, false);
+
+        WorkflowItem wfItem = WorkflowServiceFactory.getInstance().getWorkflowService().start(context, wsItem);
+
+        Item item = wfItem.getItem();
+        itemService.addMetadata(context, item, "dc", "contributor", "author", null, "Author, A. N.");
+        itemService.addMetadata(context, item, "dc", "title", null, null, "A Test Object");
+        itemService.addMetadata(context, item, "dc", "publisher", null, null, "DSpace Test Harness");
+
+        itemService.update(context, item);
+        //we need to commit the changes so we don't block the table for testing
+        context.restoreAuthSystemState();
+
+        return item;
+    }
+
+    /**
+     * Create a new, randomly generate, DOI with the given status
+     *
+     * @param item the Item to associate with the DOI
+     * @param status the status of the DOI (such as DOIIdentifierProvider.TO_BE_REGISTERED
+     * @return the String representing the DOI
+     * @throws SQLException if a database error occurs
+     * @throws AuthorizeException if an authorization error occurs
+     */
+    protected String createDOI(Item item, Integer status)
+        throws SQLException, AuthorizeException {
+        return this.createDOI(item, status, null);
+    }
+
+    /**
+     * Create a DOI to an item.
+     *
+     * @param item     Item the DOI should be created for.
+     * @param status   The status of the DOI.
+     * @param doi      The DOI or null if we should generate one.
+     * @return the DOI
+     * @throws SQLException if database error
+     */
+    protected String createDOI(Item item, Integer status, String doi)
+        throws SQLException {
+        context.turnOffAuthorisationSystem();
+        // we need some random data. UUIDs would be bloated here
+        Random random = new Random();
+        if (null == doi) {
+            doi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR
+                + Long.toHexString(Instant.now().toEpochMilli()) + "-"
+                + random.nextInt(997);
+        }
+
+        DOI doiRow = doiService.create(context);
+        doiRow.setDoi(doi.substring(DOI.SCHEME.length()));
+        doiRow.setDSpaceObject(item);
+        doiRow.setStatus(status);
+        doiService.update(context, doiRow);
+
+        //we need to commit the changes so we don't block the table for testing
+        context.restoreAuthSystemState();
+        return doi;
+    }
+
+    @Test
+    public void testPurgeEmptyDOIsWithStatus()
+        throws AuthorizeException, IllegalAccessException, IOException, SQLException, WorkflowException {
+        Item item = newItem();
+
+        // Create two DOIs, one with an item, the other with a null item
+        createDOI(item, DOIIdentifierProvider.TO_BE_REGISTERED, null);
+        createDOI(null, DOIIdentifierProvider.TO_BE_REGISTERED, null);
+
+        List<DOI> dois = doiService.getDOIsByStatus(context, Arrays.asList(DOIIdentifierProvider.TO_BE_REGISTERED));
+
+        assertThat(
+            "No DOI with null dspace_object found", dois,
+            hasItem(hasProperty("DSpaceObject", is(nullValue())))
+        );
+
+        DOIOrganiser organiser = new DOIOrganiser(context,
+            new DSpace().getSingletonService(DOIIdentifierProvider.class));
+        organiser.purgeEmptyDOIsWithStatus(context, DOIIdentifierProvider.TO_BE_REGISTERED);
+
+        dois = doiService.getDOIsByStatus(context, Arrays.asList(DOIIdentifierProvider.TO_BE_REGISTERED));
+
+        // Verify that the DOI with the null item has been removed.
+        assertThat(
+            "DOI with null dspace_object found", dois,
+            not(hasItem(hasProperty("DSpaceObject", is(nullValue()))))
+        );
+    }
+}


### PR DESCRIPTION
Modifies the "register-all" command in DOIOrganiser to delete any DOIs in a "TO_BE_REGISTERED" state that does not have an associated item ("dspace_object" in the "doi" Postgres table is null).

This is necessary because DRUM generates a DOI when an item is created, but if the item is deleted before the DOI is registered with DataCite, a NullPointerException is thrown.

Added "DOIOrganiserTest.java" to verify operation of the "purgeEmptyDOIsWithStatus" method.

Added information about this change to "DrumDOI.md" documentation.

https://umd-dit.atlassian.net/browse/LIBDRUM-916
