### PR TITLE
LIBDEVOPS-1754. Configure AWS S3 assetstore

### DIFF
--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -9,11 +9,11 @@
             <map>
                 <!-- UMD Customization -->
                 <entry key="0" value-ref="localStore"/>
-                <!--<entry key="1" value-ref="s3Store"/>-->
                 <entry key="1" value-ref="localStore1"/>
                 <entry key="2" value-ref="localStore2"/>
                 <entry key="3" value-ref="localStore3"/>
                 <entry key="4" value-ref="localStore4"/>
+                <entry key="5" value-ref="s3Store"/>
                 <!-- End UMD Customization -->
             </map>
         </property>


### PR DESCRIPTION
In "bitstore.xml" added an additional assetstore (assetstore "5") as an AWS S3 assetstore.

In order to use it for new items, DRUM must be configured to use assetstore "5" as the primary assetstore.

Note: Since the "local.cfg.EXAMPLE" file defaults to using assetstore "0", the local development environment should be unaffected by this change.

https://umd-dit.atlassian.net/browse/LIBDEVOPS-1754
