### PR TITLE
LIBDRUM-940. Added "openssh-client" to DRUM Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ ENV TZ=America/New_York
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         rsync \
+        openssh-client \
         cron \
         csh \
         postfix \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -64,6 +64,7 @@ ENV TZ=America/New_York
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         rsync \
+        openssh-client \
         cron \
         csh \
         postfix \


### PR DESCRIPTION
Modified the “Dockerfile” file to include the “openssh-client” as part of the apt-get update command used in generating the Docker image.

Also updated the “Dockerfile.dev” file for consistency with the “Dockerfile”.

The “Dockerfile.dev-additions” file, used in local development was not modified, because it did not seem to be necessary (the packages can be added as needed by developers).

https://umd-dit.atlassian.net/browse/LIBDRUM-940
