### PR TITLE
LIBDRUM-943. Back-port of DSpace 7.6.3 "ssrBaseUrl" functionality

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RootRestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RootRestResourceController.java
@@ -43,6 +43,6 @@ public class RootRestResourceController {
 
     @RequestMapping(method = RequestMethod.GET)
     public RootResource listDefinedEndpoint(HttpServletRequest request) {
-        return converter.toResource(rootRestRepository.getRoot());
+        return converter.toResource(rootRestRepository.getRoot(request));
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.converter;
 
 import static org.dspace.app.util.Util.getSourceVersion;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.RootRest;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +24,21 @@ public class RootConverter {
     @Autowired
     private ConfigurationService configurationService;
 
-    public RootRest convert() {
+    public RootRest convert(HttpServletRequest request) {
         RootRest rootRest = new RootRest();
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
         rootRest.setDspaceUI(configurationService.getProperty("dspace.ui.url"));
-        rootRest.setDspaceServer(configurationService.getProperty("dspace.server.url"));
+        String requestUrl = request.getRequestURL().toString();
+        String dspaceUrl = configurationService.getProperty("dspace.server.url");
+        String dspaceSSRUrl = configurationService.getProperty("dspace.server.ssr.url", dspaceUrl);
+        if (!dspaceUrl.equals(dspaceSSRUrl) && requestUrl.startsWith(dspaceSSRUrl)) {
+            rootRest.setDspaceServer(dspaceSSRUrl);
+        } else {
+            rootRest.setDspaceServer(dspaceUrl);
+        }
         rootRest.setDspaceVersion("DSpace " + getSourceVersion());
         return rootRest;
     }
+
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RootRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RootRestRepository.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.repository;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.converter.RootConverter;
 import org.dspace.app.rest.model.RootRest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +22,7 @@ public class RootRestRepository {
     @Autowired
     RootConverter rootConverter;
 
-    public RootRest getRoot() {
-        return rootConverter.convert();
+    public RootRest getRoot(HttpServletRequest request) {
+        return rootConverter.convert(request);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -987,21 +987,26 @@ public class Utils {
     */
     public BaseObjectRest getBaseObjectRestFromUri(Context context, String uri) throws SQLException {
         String dspaceUrl = configurationService.getProperty("dspace.server.url");
+        String dspaceSSRUrl = configurationService.getProperty("dspace.server.ssr.url", dspaceUrl);
 
         // Convert strings to URL objects.
         // Do this early to check that inputs are well-formed.
         URL dspaceUrlObject;
+        URL dspaceUrlSSRObject = null;
         URL requestUrlObject;
         try {
             dspaceUrlObject = new URL(dspaceUrl);
             requestUrlObject = new URL(uri);
+            if (StringUtils.isNoneBlank(dspaceSSRUrl)) {
+                dspaceUrlSSRObject = new URL(dspaceSSRUrl);
+            }
         } catch (MalformedURLException ex) {
             throw new IllegalArgumentException(
                     String.format("Configuration '%s' or request '%s' is malformed", dspaceUrl, uri));
         }
 
         // Check whether the URI could be valid.
-        if (!urlIsPrefixOf(dspaceUrl, uri)) {
+        if (!urlIsPrefixOf(dspaceUrl, uri) && !urlIsPrefixOf(dspaceSSRUrl, uri)) {
             throw new IllegalArgumentException("the supplied uri is not ours: " + uri);
         }
 
@@ -1011,10 +1016,15 @@ public class Utils {
         String[] requestPath = StringUtils.split(requestUrlObject.getPath(), '/');
         String[] uriParts = Arrays.copyOfRange(requestPath, dspacePathLength,
                 requestPath.length);
+
+        int dspaceSSRPathLength = StringUtils.split(dspaceUrlSSRObject.getPath(), '/').length;
+        String[] uriSSRParts = Arrays.copyOfRange(requestPath, dspaceSSRPathLength,
+            requestPath.length);
+
         if ("api".equalsIgnoreCase(uriParts[0])) {
             uriParts = Arrays.copyOfRange(uriParts, 1, uriParts.length);
         }
-        if (uriParts.length != 3) {
+        if (uriParts.length != 3 && uriSSRParts.length != 3) {
             throw new IllegalArgumentException("the supplied uri lacks required path elements: " + uri);
         }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -847,7 +847,6 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
      *
      * @throws Exception
      */
-    @Test
     public void findByObjectSSRTest() throws Exception {
         Site site = siteService.findSite(context);
         SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -28,6 +28,10 @@ csvexport.dir = ${dspace.dir}/exports
 # and is usually "synced" with the "rest" section in the DSpace User Interface's config.*.yml.
 # It corresponds to the URL that you would type into your browser to access the REST API.
 dspace.server.url = http://localhost:8080/server
+# Additional URL of DSpace backend which could be used by DSpace frontend during SSR execution.
+# May require a port number if not using standard ports (80 or 443)
+# DO NOT end it with '/'.
+dspace.server.ssr.url = ${dspace.server.url}
 
 # Public URL of DSpace frontend (Angular UI). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -48,6 +48,11 @@ dspace.url = ${dspace.baseUrl}
 dspace.server.url = ${dspace.baseUrl}/server
 # End UMD Customization
 
+# Additional URL of DSpace backend which could be used by DSpace frontend during SSR execution.
+# May require a port number if not using standard ports (80 or 443)
+# DO NOT end it with '/'.
+dspace.server.ssr.url = ${dspace.server.url}
+
 # Public URL of DSpace frontend (Angular UI). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.


### PR DESCRIPTION
Back-port of "ssrBaseUrl" functionality from
DSpace pull request 10374

Implements the ability for Angular Universal to
communicate directly with the DRUM back-end
pod, instead of going through the ingress.

This change was needed for the AWS migration.

https://umd-dit.atlassian.net/browse/LIBDRUM-943
