### PR TITLE
LIBDRUM-971. Pin Solr version in "docker-compose" to "dspace-8_x"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
-    image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-8_x}"
     build:
       context: ./dspace/src/main/docker/dspace-solr/
       # Provide path to Solr configs necessary to build Docker image


### PR DESCRIPTION
Set the default Solr version to "dspace-8_x", so that the Solr version doesn't change unexpectedly when running in the local development environment.

This change matches the change in the "dspace-8_x" branch for post-DSpace 8.0 changes.

https://umd-dit.atlassian.net/browse/LIBDRUM-971
