### PR TITLE
LIBDRUM-985. Converted "load-etd-nightly" to Bash

### DIFF
--- a/dspace/bin/load-etd-nightly
+++ b/dspace/bin/load-etd-nightly
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/bin/bash
 
 # load-etd-nightly
 #
@@ -7,47 +7,36 @@
 #
 
 # Get command-line arguments
-if ($#argv != 1) then
+if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <dir>"
     echo "    <dir>:    Directory containing Proquest ETD files"
-    exit 0
-endif
+    exit 1
+fi
 
-set datadir = `cd $argv[1]; pwd`
-set bindir  = `dirname $0`
-set incomingdir = $datadir/incoming
-set processeddir = $datadir/processed
+datadir=$(cd "$1"; pwd)
+bindir=$(dirname "$0")
+incomingdir="$datadir/incoming"
+processeddir="$datadir/processed"
 
 # Check for incoming files
-ls $incomingdir/etdadmin_upload_*.zip >& /dev/null
-if ($status == 0) then
-  echo Files found in $incomingdir
+if ls "$incomingdir"/etdadmin_upload_*.zip &> /dev/null; then
+  echo "Files found in $incomingdir"
 
-  @ count = 0
-
-  foreach upload ($incomingdir/etdadmin_upload_*.zip)
-    set zipfile = `basename $upload`
+  for upload in "$incomingdir"/etdadmin_upload_*.zip; do
+    zipfile=$(basename "$upload")
 
     # Load the files from this archive
     echo
-    echo ======================================================================
-    echo Loading archive file: $incomingdir/$zipfile
-    $bindir/load-etd -i $incomingdir/$zipfile
+    echo "======================================================================"
+    echo "Loading archive file: $incomingdir/$zipfile"
+    "$bindir/load-etd" -i "$incomingdir/$zipfile"
 
     # Move archive to the processed directory
-    if (! -d $processeddir ) then
-      mkdir -p $processeddir
-    endif
+    if [ ! -d "$processeddir" ]; then
+      mkdir -p "$processeddir"
+    fi
     echo
-    echo ' ' Moving $zipfile to $processeddir
-    mv $incomingdir/$zipfile $processeddir
-
-    @ count = $count + 1
-  end
-endif
-
-
-
-
-
-
+    echo " Moving $zipfile to $processeddir"
+    mv "$incomingdir/$zipfile" "$processeddir"
+  done
+fi


### PR DESCRIPTION
Converted the "load-etd-nightly" script from C Shell to Bash (with the help of TerpAI).

Removed the "count" variable, because it is no longer needed (it is a remnant of the MARC/CSV functionality of the script that was removed in earlier commits).

Also, If an argument specifying the directory to import from is not specified, the script exits with an exit code of 1 instead of 0. This is unlikely to occur in practice, and returning 1 is more correct from a Unix perspective (as not supplying an argument is an error).

https://umd-dit.atlassian.net/browse/LIBDRUM-985

