### PR TITLE
LIBDRUM-1010. Updated Metadata Export limit to be effectively unlimited

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -432,4 +432,9 @@ data.community.handle = 1903/27669
 # Equitable Access Policy
 # The handle for the "Equitable Access Policy" community
 equitable_access_policy.community.handle = 1903/29474
+
+# Batch Metadata export
+# Intended to allow an unlimited number of items by setting the number to be
+# larger than the total number of items in DRUM.
+bulkedit.export.max.items = 999999
 # End UMD Customization


### PR DESCRIPTION
Updated the Batch Metadata Export limit (which defaults to 500 items in stock DSpace) to be effectively unlimited by overriding the "bulkedit.export.max.items" property and setting it to 999,9999 items.

Note a positive integer must be specified -- "0" or "-1" do not denote "unlimited" for this property.

This change was made at the request of stakeholders who were confused why DRUM only allowed 500 items to be exported.

https://umd-dit.atlassian.net/browse/LIBDRUM-1010
