### PR TITLE
LIBDRUM-999. Remove obsolete DRUM configuration properties

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -396,12 +396,8 @@ usage-statistics.authorization.admin.usage=true
 #######################
 
 # ETD loader email settings
-drum.mail.etdmarc.recipient = mohideen@umd.edu
 drum.mail.etd.recipient = mohideen@umd.edu
 drum.mail.duplicate_title = mohideen@umd.edu
-
-# Used by daily subscription mailer
-drum.eperson.subscription.limiteperson =
 
 # Used by etd loader cron job
 drum.etdloader.eperson = load_diss@drum.umd.edu


### PR DESCRIPTION
Removed following configuration properties as they are no longer used:

* drum.mail.etdmarc.recipient - Need for this property was removed in LIBDRUM-972
* drum.eperson.subscription.limiteperson - Functionality removed in LIBDRUM-749

https://umd-dit.atlassian.net/browse/LIBDRUM-999
