### PR TITLE
LIBDRUM-909. Provide separate umdDescribe/mhheaDescribe form configs

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -53,10 +53,10 @@
         <name-map collection-handle="123456789/29" submission-name="JournalVolume"/>
         <name-map collection-handle="123456789/30" submission-name="JournalIssue"/>
         -->
-        <!-- These configurations enable default submission forms per Entity type 
-            
+        <!-- These configurations enable default submission forms per Entity type
+
             The  collection-entity-type will be the entity-type attribute associated with a collection,
-            typically the entity name that is associated with a collection if any created or loaded 
+            typically the entity name that is associated with a collection if any created or loaded
             (that is usually specified in relationship-types.xml).
             - - - - - -
             PLEASE NOTICE THAT YOU WILL HAVE TO RESTART DSPACE
@@ -248,20 +248,13 @@
         </step-definition>
 
         <!-- UMD Customization -->
-        <!-- LIBDRUM-876 -->
-        <step-definition id="umdType" mandatory="true">
-          <heading>submit.progressbar.describe.umdType</heading>
-          <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
-          <type>submission-form</type>
-        </step-definition>
-
-        <step-definition id="mhheaType" mandatory="true">
-          <heading>submit.progressbar.describe.mhheaType</heading>
-          <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
-          <type>submission-form</type>
-        </step-definition>
-
         <step-definition id="umdDescribe" mandatory="true">
+            <heading>submit.progressbar.describe.stepone</heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+
+        <step-definition id="mhheaDescribe" mandatory="true">
             <heading>submit.progressbar.describe.stepone</heading>
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
             <type>submission-form</type>
@@ -465,7 +458,6 @@
         <!-- UMD default submission process -->
         <submission-process name="umd-submission">
             <step id="collection"/>
-            <step id="umdType"/>
             <step id="umdDescribe"/>
             <step id="upload"/>
             <step id="cclicense"/>
@@ -477,12 +469,11 @@
             collection -->
         <submission-process name="MHHEA-submission">
             <step id="collection"/>
-            <step id="mhheaType"/>
-            <step id="umdDescribe"/>
+            <step id="mhheaDescribe"/>
             <step id="optionalUpload"/>
             <step id="cclicense"/>
             <step id="license"/>
-        </submission-process> -->
+        </submission-process>
         <!-- End UMD Customization -->
     </submission-definitions>
 

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1325,9 +1325,26 @@
             </row>
         </form>
 
-        <!-- UMD Customization -->
-        <!-- "Type" field (with Equitable Access question) for default UMD submissions -->
-        <form name="umdType">
+        <!--
+          "Describe" form for UMD submissions.
+
+          This is the default form for submissions, except for submissions
+          to the  MHHEA (Minority Health and Health Equity Archive) collection,
+          (see "mhheaDescribe" form).
+
+          This form has both a "custom" and "common" section. Changes to the
+          The "common" section should be replicated in the "mhheaDescribe" form
+          (and vice versa).
+
+          The "custom" section displays input components for the "dc.type" and
+          "local.equitableAccessSubmission".
+        -->
+        <form name="umdDescribe">
+            <!--
+              Custom section for "umdDescribe"
+              Displays/hides Equitable Access Field based on dc.type
+              DO NOT place in "mhheaDescribe"
+            -->
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>
@@ -1358,28 +1375,14 @@
                     </type-bind>
                 </field>
             </row>
-        </form>
-
-        <!-- "Type" field (without Equitable Access question) for MHHEA submissions -->
-        <form name="mhheaType">
-            <row>
-                <field>
-                    <dc-schema>dc</dc-schema>
-                    <dc-element>type</dc-element>
-                    <dc-qualifier></dc-qualifier>
-                    <repeatable>false</repeatable>
-                    <label>Type</label>
-                    <input-type value-pairs-name="umd_common_types">dropdown</input-type>
-                    <hint>Select the type of content of the item.
-                    </hint>
-                    <required>Please select a type for this item.</required>
-                </field>
-            </row>
-        </form>
-
-        <!-- Default "Describe" form for UMD submissions. Used for both
-             default and MHHEA submissions -->
-        <form name="umdDescribe">
+            <!--
+              End Custom section for "umdDescribe".
+            -->
+            <!--
+              Common section for "umdDescribe"
+              Any changes made in this section should be replicated in
+              "mhheaDescribe".
+            -->
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>
@@ -1710,6 +1713,379 @@
                     <required></required>
                 </field>
             </row>
+            <!-- End Common section for "umdDescribe"-->
+        </form>
+
+        <!--
+          "Describe" form for MHHEA (Minority Health and Health Equity Archive)
+          submissions.
+
+          This form is indented to be the same as the "umdDescribe" form, with
+          the following differences:
+            * the "local.equitableAccessSubmission" field is *not* displayed.
+
+          This form has both a "custom" and "common" section. Changes to the
+          The "common" section should be replicated in the "umdDescribe" form
+          (and vice versa).
+        -->
+        <form name="mhheaDescribe">
+            <!--
+              Custom section for "mhheaDescribe"
+              "Type" field (without Equitable Access question)
+              DO NOT place in "umdDescribe"
+            -->
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>type</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Type</label>
+                    <input-type value-pairs-name="umd_common_types">dropdown</input-type>
+                    <hint>Select the type of content of the item.
+                    </hint>
+                    <required>Please select a type for this item.</required>
+                </field>
+            </row>
+            <!--
+              End Custom section for "mhheaDescribe".
+            -->
+            <!--
+              Common section with "umdDescribe"
+              Any changes made in this section should be replicated in
+              "umdDescribe".
+            -->
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>author</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Author (Last Name, First Name)</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the author's name (Last name, First name).</hint>
+                    <required>You must enter an author for this item.</required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>advisor</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Advisor (Last Name, First Name)</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the advisor's name (Last name, First name).</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Title</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the main title of the item.</hint>
+                    <required>You must enter a main title for this item.</required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier>alternative</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Other Titles</label>
+                    <input-type>onebox</input-type>
+                    <hint>If the item has any alternative titles, please enter them here.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>date</dc-element>
+                    <dc-qualifier>issued</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Date of Issue</label>
+                    <style>col-sm-4</style>
+                    <input-type>date</input-type>
+                    <hint>Please give the date of previous publication or public distribution.
+                        You can leave out the day and/or month if they aren't applicable.
+                    </hint>
+                    <required>You must enter at least the year.</required>
+                </field>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>publisher</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Publisher</label>
+                    <style>col-sm-8</style>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>uri</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Publication or External Link</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>
+                        Enter the DOI (Digital Object Identifier) or other external link to the published version of this research work.
+                    </hint>
+                    <required></required>
+                    <regex>^(https*|DOI):(\/\/)*.*</regex>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>uri</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Related Publication Link</label>
+                    <type-bind>
+                        <!-- Should display only for "Dataset" and "Software" -->
+                        Dataset,
+                        Software
+                    </type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>
+                        Enter the link to any research publication supported by the dataset or software. If available, please use the DOI (Digital Object Identifier) for the publication.
+                    </hint>
+                    <required></required>
+                    <regex>^(https*|DOI):(\/\/)*.*</regex>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier>citation</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Publication Citation</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>If the item has been previously published or has a corresponding publication, enter its bibliographic citation.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier>citation</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Related Publication Citation</label>
+                    <type-bind>
+                        <!-- Should display only for "Dataset" and "Software" -->
+                        Dataset,
+                        Software
+                    </type-bind>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the standard citation for any research publication supported by the dataset or software.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>relation</dc-element>
+                    <dc-qualifier>ispartofseries</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Series/Report No.</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
+                    <input-type>series</input-type>
+                    <hint>Enter the series and number assigned to this item by your community.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <label>Identifiers</label>
+                    <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
+                    <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+                    <hint>If the item has any identification numbers or codes associated with
+                        it, please enter the types and the actual numbers or codes.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>language</dc-element>
+                    <dc-qualifier>iso</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Language</label>
+                    <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+                    <hint>Select the language of the main content of the item. If the language does not appear in the
+                        list, please select 'Other'. If the content does not really have a language (for example, if it
+                        is a dataset or an image) please select 'N/A'.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>subject</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Subject Keywords</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter appropriate subject keywords or phrases. To add multiple subject keywords, enter one term or phrase at a time and then click "Add more".</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>abstract</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Abstract</label>
+                    <input-type>textarea</input-type>
+                    <hint>Enter the abstract of the item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>sponsorship</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Sponsors</label>
+                    <input-type>textarea</input-type>
+                    <hint>Enter the names of any sponsors and/or funding codes in the box.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Description</label>
+                     <type-bind>
+                        <!-- Should display for all umd_common_types, except "Dataset" and "Software" -->
+                        Article,
+                        Audiovisual,
+                        Book,
+                        Book chapter,
+                        <!-- Dataset, -->
+                        Dissertation,
+                        Image,
+                        Preprint,
+                        Presentation,
+                        Report,
+                        <!-- Software, -->
+                        Thesis,
+                        Working Paper,
+                        Other
+                    </type-bind>
+                    <input-type>textarea</input-type>
+                    <hint>Enter any other description or comments in this box.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Methodology Description</label>
+                    <type-bind>
+                        <!-- Should display only for "Dataset" and "Software" -->
+                        Dataset,
+                        Software
+                    </type-bind>
+                    <input-type>textarea</input-type>
+                    <hint>Description of methods used for data collection/generation, processing, analysis, standards, quality-assurance procedures, etc.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <!-- End Common section with "umdDescribe"-->
         </form>
         <!-- End UMD Customization -->
 

--- a/dspace/docs/DrumSubmissionForms.md
+++ b/dspace/docs/DrumSubmissionForms.md
@@ -16,6 +16,7 @@ process.
 * LIBDRUM-729
 * LIBDRUM-747
 * LIBDRUM-876
+* LIBDRUM-909
 
 ## Submission Forms
 
@@ -132,14 +133,28 @@ DSpace:
 
 ### Equitable Access Submission Form Changes
 
-Both the default and MHHEA submission forms have a "Submission Type" step that
-contains the "Type" field.
-
 In the default submission form, selecting "Article" in the "Type" field
 dynamically displays the "Equitable Access" field.
 
 In the MHHEA form, the "Equitable Access" field is never displayed, as MHHEA
 submissions are never added to the "Equitable Access Policy" collection.
+
+The disparate treatment of the "Equitable Access" between the default and MHHEA
+submission forms is handled by having completely separate configurations for
+these forms (see "umdDescribe" and "mhheaDescribe" in
+"dspace/config/submission-forms.xml").
+
+Each form definition has a "custom" and "common" section. The "custom" section
+in each definition handles the "Equitable Access" field. The "common" section
+in each definition are the fields that are the same in both forms.
+
+Keeping the two "common" sections in sync must be done manually.
+
+**Note:** The initial implementation of the "Equitable Access" functionality in
+LIBDRUM-876 used separate submission form configurations to handle the "custom"
+(Type, Equitable Access) functionality and a single "common" configuration for
+the remaining fields. Unfortunately, this resulted in issues such as
+LIBDRUM-909, in which required field warnings were not being displayed.
 
 ### "local.equitableAccessSubmission" metadata field
 

--- a/dspace/docs/DrumTestPlan.md
+++ b/dspace/docs/DrumTestPlan.md
@@ -170,17 +170,17 @@ The "New item" modal dialog will be displayed.
 
 6.3) Upload a PDF file to the page by dragging and dropping it onto the page.
 
-6.4) Change the "Type" dropdown in the "Submission Type" panel to "Article".
+6.4) Change the "Type" dropdown in the "Describe" panel to "Article".
 Verify that an additional "Equitable Access" dropdown with the label
 
 > Is this article being submitted to comply with the "Equitable Access to
 > Scholarly Articles Authored by University Faculty"
 > (<https://equitableaccess.umd.edu/>) policy?"
 
-is added to the "Submission Type" panel.
+is displayed.
 
 6.5) Change the "Type" dropdown to "Book". Verify that the "Equitable Access"
-dropdown field is removed from the "Submission Type" panel.
+dropdown field is removed.
 
 6.6) Fill out the following fields:
 


### PR DESCRIPTION
Fixes validation error display rendering by creating a separate "mhheaDescribe" form for use with
Minority Health and Health Equity Archive submisions, modeled on the the standard "umdDescribe" form.

This eliminates the need for a separate "Submission Type" panel from both forms. Having this separate panel appears to be the source of the error validation display issue.

The "umdDescribe" and "mhheaDescribe" forms are commented with "custom" and "common" sections. The "custom" section in "umdDescribe" handles the dynamic display of the "Equitable Access" field when specific document types are selected. The "custom" section in "mhheaDescribe" does not have this functionality, as it is not needed.

The "common" sections of both forms should remain in sync -- updates to one should be (manually) replicated in the other. There is no way to enforce this, other than through mentioning it in the documentation.

https://umd-dit.atlassian.net/browse/LIBDRUM-909
