### PR TITLE
LIBDRUM-1032. Minor tweak to "docker-compose-cli.yml" file

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -20,7 +20,7 @@ services:
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # db.url: Ensure we are using the 'dspacedb' image for our database
       # UMD Customization
-      db__P__url: {db__P__url:-jdbc:postgresql://dspacedb:5432/drum}
+      db__P__url: ${db__P__url:-jdbc:postgresql://dspacedb:5432/drum}
       # End UMD Customization
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
       solr__P__server: ${solr__P__server:-http://dspacesolr:8983/solr}


### PR DESCRIPTION
While working on the MD-SOAR DSpace 8.4 update, noticed this typo in the DRUM "docker-compose-cli.yml" file when comparing files.

This change was *not* part of the "8.4-drum-0" release, and is believed to have no impact on that release, because we typically do not run this Docker Compose file.

https://umd-dit.atlassian.net/browse/LIBDRUM-1032
