### PR TITLE
LIBDRUM-1033. Added "About DRUM" link verification to test plan

### DIFF
--- a/dspace/docs/DrumFeatures.md
+++ b/dspace/docs/DrumFeatures.md
@@ -123,6 +123,7 @@ LIBDRUM-1007.
 * LIBDRUM-746 - "Abstract" field modified to not preserve line breaks when
   displayed
 * LIBDRUM-844 - Disable "By Subject Category" Browse option
+* LIBDRUM-1033 - "About DRUM" link (with associated page) added to navigation bar
 
 ## DRUM DOI
 

--- a/dspace/docs/DrumTestPlan.md
+++ b/dspace/docs/DrumTestPlan.md
@@ -55,6 +55,8 @@ The DRUM home page will be displayed.
 * The UMD favicon is displayed in the browser tab, and that the text in
   the browser tab is "DRUM :: Home"
 * The appropriate SSDR environment banner is displayed.
+* There is an "About Drum" link in the navigation bar, immediately after the
+  logo that links to the "About DRUM" page
 * The lower half of the page contains two columns:
   * "List of Communities"
   * "Recent Submissions"


### PR DESCRIPTION
Added an additional item to the test plan to verify that there is an "About DRUM" link in the navigation menubar.

Also added entry to "docs/DrumFeatures.md" regarding the addition of the "About DRUM" link to the navigation bar.

https://umd-dit.atlassian.net/browse/LIBDRUM-1033
