### PR TITLE
LIBDRUM-1036. Added "Accessibility" panel to submission form

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V8.4_2026.08.03__umd_add_accessibility_metadata_field.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V8.4_2026.08.03__umd_add_accessibility_metadata_field.sql
@@ -1,0 +1,26 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- Flyway Migration: Add local.accessibility.acknowledged metadata field
+-- Ensures the row isn't duplicated if run multiple times
+
+INSERT INTO metadatafieldregistry (metadata_schema_id, element, qualifier, scope_note)
+SELECT
+    ms.metadata_schema_id,
+    'accessibility' AS element,
+    'acknowledged' AS qualifier,
+    'User acknowledgment that submission is subject to DRUM accessibility policies.' AS scope_note
+FROM metadataschemaregistry ms
+WHERE ms.short_id = 'local'
+  AND NOT EXISTS (
+        SELECT 1
+        FROM metadatafieldregistry mfr
+        WHERE mfr.metadata_schema_id = ms.metadata_schema_id
+          AND mfr.element = 'accessibility'
+          AND mfr.qualifier = 'acknowledged'
+    );

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -254,6 +254,12 @@
             <type>submission-form</type>
         </step-definition>
 
+        <step-definition id="umdAccessibility" mandatory="true">
+            <heading>submit.progressbar.umdAccessibility</heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+
         <step-definition id="mhheaDescribe" mandatory="true">
             <heading>submit.progressbar.describe.stepone</heading>
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
@@ -462,6 +468,7 @@
             <step id="upload"/>
             <step id="cclicense"/>
             <step id="license"/>
+            <step id="umdAccessibility"/>
         </submission-process>
 
         <!--This "MHHEA-submission" process replaces the DEFAULT item submission
@@ -473,6 +480,7 @@
             <step id="optionalUpload"/>
             <step id="cclicense"/>
             <step id="license"/>
+            <step id="umdAccessibility"/>
         </submission-process>
         <!-- End UMD Customization -->
     </submission-definitions>

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -466,9 +466,9 @@
             <step id="collection"/>
             <step id="umdDescribe"/>
             <step id="upload"/>
+            <step id="umdAccessibility"/>
             <step id="cclicense"/>
             <step id="license"/>
-            <step id="umdAccessibility"/>
         </submission-process>
 
         <!--This "MHHEA-submission" process replaces the DEFAULT item submission
@@ -478,9 +478,9 @@
             <step id="collection"/>
             <step id="mhheaDescribe"/>
             <step id="optionalUpload"/>
+            <step id="umdAccessibility"/>
             <step id="cclicense"/>
             <step id="license"/>
-            <step id="umdAccessibility"/>
         </submission-process>
         <!-- End UMD Customization -->
     </submission-definitions>

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -5,7 +5,7 @@
   - An empty registry for instance-specific, local metadata. Any non-standard
   - metadata fields should be added here to avoid polluting the standard
   - namespaces.
-  - 
+  -
   -->
 <dspace-dc-types>
 
@@ -38,6 +38,14 @@
     <element>equitableAccessSubmission</element>
     <qualifier></qualifier>
     <scope_note>Indicates whether item is being submitted in compliance with the UMD "Equitable Access" policy</scope_note>
+  </dc-type>
+  <dc-type>
+    <schema>local</schema>
+    <element>accessibility</element>
+    <qualifier>acknowledged</qualifier>
+    <scope_note>
+      Indicates that the submitter has acknowledged submission is subject to the DRUM Accessibility policy.
+    </scope_note>
   </dc-type>
   <!-- End UMD Customization -->
 

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -2817,7 +2817,7 @@
         </value-pairs>
         <value-pairs value-pairs-name="umd_accessibility_acknowledgment" dc-term="accessibility">
           <pair>
-            <displayed-value>I acknowledge that my submission is subject to the accessibility requirements under the terms of the DRUM Accessibility Policy.</displayed-value>
+            <displayed-value>I confirm I have reviewed DRUM's Accessibility (https://drum.lib.umd.edu/info/drum-about#accessibility) requirements and will work with DRUM administrators to ensure my deposited materials are digitally accessible.</displayed-value>
             <stored-value>true</stored-value>
           </pair>
         </value-pairs>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1726,7 +1726,7 @@
                     <label>Accessibility Acknowledgment</label>
                     <input-type value-pairs-name="umd_accessibility_acknowledgment">list</input-type>
                     <hint></hint>
-                    <required>You must acknowledge that your submission is subject to the DRUM Accessibility Policy.</required>
+                    <required>You must confirm that you have reviewed DRUM's Accessibility requirements.</required>
                 </field>
             </row>
         </form>
@@ -2817,7 +2817,7 @@
         </value-pairs>
         <value-pairs value-pairs-name="umd_accessibility_acknowledgment" dc-term="accessibility">
           <pair>
-            <displayed-value>I confirm I have reviewed DRUM's Accessibility (https://drum.lib.umd.edu/info/drum-about#accessibility) requirements and will work with DRUM administrators to ensure my deposited materials are digitally accessible.</displayed-value>
+            <displayed-value>I confirm I have reviewed DRUM's Accessibility requirements (https://lib.guides.umd.edu/accessible-scholarship).</displayed-value>
             <stored-value>true</stored-value>
           </pair>
         </value-pairs>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1716,6 +1716,21 @@
             <!-- End Common section for "umdDescribe"-->
         </form>
 
+        <form name="umdAccessibility">
+            <row>
+                <field>
+                    <dc-schema>local</dc-schema>
+                    <dc-element>accessibility</dc-element>
+                    <dc-qualifier>acknowledged</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Accessibility Acknowledgment</label>
+                    <input-type value-pairs-name="umd_accessibility_acknowledgment">list</input-type>
+                    <hint></hint>
+                    <required>You must acknowledge that your submission is subject to the DRUM Accessibility Policy.</required>
+                </field>
+            </row>
+        </form>
+
         <!--
           "Describe" form for MHHEA (Minority Health and Health Equity Archive)
           submissions.
@@ -2799,6 +2814,12 @@
                 <displayed-value>Other</displayed-value>
                 <stored-value>Other</stored-value>
             </pair>
+        </value-pairs>
+        <value-pairs value-pairs-name="umd_accessibility_acknowledgment" dc-term="accessibility">
+          <pair>
+            <displayed-value>I acknowledge that my submission is subject to the accessibility requirements under the terms of the DRUM Accessibility Policy.</displayed-value>
+            <stored-value>true</stored-value>
+          </pair>
         </value-pairs>
         <!-- End UMD Customization -->
 

--- a/dspace/docs/DrumSubmissionForms.md
+++ b/dspace/docs/DrumSubmissionForms.md
@@ -17,6 +17,7 @@ process.
 * LIBDRUM-747
 * LIBDRUM-876
 * LIBDRUM-909
+* LIBDRUM-1036
 
 ## Submission Forms
 
@@ -187,3 +188,16 @@ steps, and modified the "finaleditstep" to go to the "umdcollectionmapping" when
 it completes. Modifying the "finaleditstep" appears to be necessary –
 despite how it may seem from the documentation - as the workflow steps to not
 naturally progress through all the steps in the list.
+
+## Accessibility Form Changes
+
+An "Accessibility" panel was added with a required field that the user must
+select acknowledging that the submission is subject to the DRUM accessibility
+policy.
+
+### "local.accessibility.acknowledged" metadata field
+
+A "local.accessibility.acknowledged" metadata field was added to track the
+user's response to the accessibility acknowledgment question on the submission
+form. This metadata field, when populated, should always be "true", and
+shows up in the "Full item page" view for the item.

--- a/dspace/docs/DrumTestPlan.md
+++ b/dspace/docs/DrumTestPlan.md
@@ -205,7 +205,13 @@ entries (but do not select either of them):
 * Creative Commons
 
 In the "Deposit license" section, left-click the "I confirm the license above"
-checkbox, and then left-click the "Deposit" button. A notification will be
+checkbox to select it.
+
+In the "Accessibility" section, left-click the accessibility acknowledgment in
+the "Accessibility" section to select it, and then left-click the "Deposit"
+button.
+
+A notification will be
 displayed indicating that the item was successfully deposited. The
 "My submissions" page will be displayed.
 

--- a/dspace/docs/DrumTestPlan.md
+++ b/dspace/docs/DrumTestPlan.md
@@ -198,6 +198,9 @@ dropdown field is removed.
 | Title | SSDR Test Item |
 | Date of Issue | <Enter "2025" in the "Year" field> |
 
+In the "Accessibility" section, left-click the accessibility
+confirmation to select it.
+
 Verify that the "Creative commons license" section has a dropdown with two
 entries (but do not select either of them):
 
@@ -205,15 +208,10 @@ entries (but do not select either of them):
 * Creative Commons
 
 In the "Deposit license" section, left-click the "I confirm the license above"
-checkbox to select it.
+checkbox to select it, and then left-click the "Deposit" button
 
-In the "Accessibility" section, left-click the accessibility acknowledgment in
-the "Accessibility" section to select it, and then left-click the "Deposit"
-button.
-
-A notification will be
-displayed indicating that the item was successfully deposited. The
-"My submissions" page will be displayed.
+A notification will be displayed indicating that the item was successfully
+deposited. The "My submissions" page will be displayed.
 
 6.7) On the "My submissions" page, verify that the item has been added as one
 of the submissions. Left-click the "View" button for the submitted item. The


### PR DESCRIPTION
Added an "Accessibility" panel to display a required field that the used must select, acknowledging that the submission is subject to the DRUM accessibility policies.

The custom "local.accessibility.acknowledged" metadata field was added to store the user response.

A Postgres migration was added to ensure that the
"local.accessibility.acknowledged" metadata field is added to the database.

Updated the documentation and test plan with information about the "Accessibility" section in the submission form.

https://umd-dit.atlassian.net/browse/LIBDRUM-1036
